### PR TITLE
Switch TypeScript moduleResolution to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
This fixes the following type error:

> Error: src/components/ui/Earth3D.tsx(4,27): error TS2307: Cannot find module 'three/addons/loaders/SVGLoader.js' or its corresponding type declarations.
>   There are types at '/home/runner/work/next-website-v2/next-website-v2/node_modules/@types/three/examples/jsm/loaders/SVGLoader.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

However, I don't know much about what the different moduleResolution options actually mean, so I'm not sure if this is the best way to fix it.