### PR TITLE
feat: add port to gitpod (fixes #199)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,3 +10,8 @@ tasks:
     command: yarn run dev
   - name: Bash
     command: bash
+
+ports:
+  - port: 3000
+    name: app
+    onOpen: open-preview


### PR DESCRIPTION
## What changed?

Add the port to the gitpod config

closes #199 

## How will this change be visible?

gitpod will make the port visible as a preview

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (preview works)
