### PR TITLE
bug: Fix image yarn lint issues in BoardMembers and CampaignCard comps

### DIFF
--- a/src/components/about-us/BoardMembers.tsx
+++ b/src/components/about-us/BoardMembers.tsx
@@ -1,10 +1,10 @@
-import Image from "@/components/image/Image";
+import ImageComponent from "@/components/image/Image";
 import { FC } from "react";
 import boardSrc from "../../../public/images/about-us/board.jpg";
 
 const BoardMembers: FC = () => (
   <section className="py-12 lg:py-20">
-    <Image
+    <ImageComponent
       image={boardSrc.src}
       width={600}
       height={300}

--- a/src/components/donate/CampaignCard.tsx
+++ b/src/components/donate/CampaignCard.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { FC } from "react";
+import Image from "next/image";
 
 const CampaignCard: FC<{
   imgSrc: string;
@@ -23,9 +24,12 @@ const CampaignCard: FC<{
     <Box asChild width="373px">
       <Card>
         <Inset clip="padding-box" pb="current">
-          <img
+          <Image
             src={imgSrc}
             alt={imgAlt}
+            height={0}
+            width={0}
+            sizes={"100vw"}
             style={{
               display: "block",
               objectFit: "cover",
@@ -33,7 +37,7 @@ const CampaignCard: FC<{
               height: 150,
               backgroundColor: "var(--blue-9)",
             }}
-          ></img>
+          />
           <Flex
             direction="row"
             align="center"


### PR DESCRIPTION
## What changed?

https://github.com/distributeaid/next-website-v2/issues/197

Changed the CampaignCard image to a next/image component. Used this trick to keep widths dynamic: https://github.com/vercel/next.js/discussions/18474#discussioncomment-5501724

On the BoardMembers component, I change the naming of the component from just Image to ImageWithCaption. This avoids next/image conflicts. **Custom components should always avoid sharing common Next.js component names (eg `<Image />`)**

**Future improvement:** Change the custom component to a more generic name, change the caption/attribution properties to optional so the component can easily be reused in CampaignCard and other parts of the site to avoid next/image component reuse and redundancy.

## How will this change be visible?

On the donate/new-donate page for the CampaignCard component, the /about-us page for the BoardMembers component

## How can you test this change?

- [X] Automated tests
- [X] Manual tests (describe) Verified images are loading in and responsive as expected compared to before the changes
