### PR TITLE
fix/212: navbar shows underline on hover

### DIFF
--- a/src/components/nav/navBar.tsx
+++ b/src/components/nav/navBar.tsx
@@ -132,17 +132,17 @@ const NavBar = () => {
                   {/* <NavigationMenu.Trigger > */}
                   <Box asChild py="3" px={{ sm: "3", md: "6" }}>
                     <Text asChild wrap="nowrap">
-                      <Link
-                        className={cx(
-                          " cursor-pointer capitalize font-medium hover:underline decoration-2 underline-offset-8 duration-200",
-                          {
-                            //a separate donate button is used for proper spacing
-                            "hidden ": id === 7,
-                          },
-                        )}
-                        href={url}
-                      >
-                        <NavigationMenu.Trigger>
+                      <NavigationMenu.Trigger>
+                        <Link
+                          className={cx(
+                            " cursor-pointer capitalize font-medium hover:underline decoration-2 underline-offset-8 duration-200",
+                            {
+                              //a separate donate button is used for proper spacing
+                              "hidden ": id === 7,
+                            },
+                          )}
+                          href={url}
+                        >
                           {isSubMenu ? (
                             <Flex position={"relative"} align={"center"}>
                               {title}
@@ -176,8 +176,8 @@ const NavBar = () => {
                           ) : (
                             title
                           )}
-                        </NavigationMenu.Trigger>
-                      </Link>
+                        </Link>
+                      </NavigationMenu.Trigger>
                     </Text>
                   </Box>
                 </NavigationMenu.Item>


### PR DESCRIPTION
## What changed?
changed trigger to properly show navbar links' underline on hover
<!-- include a link to a GitHub issue, if applicable -->
#212 
## How will this change be visible?
on hover, navbar links  should be underlined
<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (describe)
hover over navbar links to show underline