### PR TITLE
task: commented our 'Regions' and 'Needs' from navbar, also replaced …

### DIFF
--- a/src/data/navBarLinks.ts
+++ b/src/data/navBarLinks.ts
@@ -11,57 +11,57 @@ export const links = [
     url: "/about-us",
     isSubMenu: false,
   },
-  {
-    id: 3,
-    title: "Needs",
-    url: "/needs-assessment",
-    isSubMenu: true,
-    subMenu: [
-      {
-        id: 3.1,
-        title: "Overview",
-        url: "/needs-assessment",
-      },
-      {
-        id: 3.2,
-        title: "Data Explorer",
-        url: "/needs-assessment",
-      },
-      {
-        id: 3.3,
-        title: "Methodology",
-        url: "/needs-assessment",
-      },
-    ],
-  },
-  {
-    id: 4,
-    title: "Regions",
-    url: "/regions",
-    isSubMenu: true,
-    subMenu: [
-      {
-        id: 4.1,
-        title: "Overview",
-        url: "/regions",
-      },
-      {
-        id: 4.2,
-        title: "USA",
-        url: "/regions",
-      },
-      {
-        id: 4.3,
-        title: "Europe",
-        url: "/regions",
-      },
-      {
-        id: 4.4,
-        title: "Middle East",
-        url: "/regions",
-      },
-    ],
-  },
+  // {
+  //   id: 3,
+  //   title: "Needs",
+  //   url: "/needs-assessment",
+  //   isSubMenu: true,
+  //   subMenu: [
+  //     {
+  //       id: 3.1,
+  //       title: "Overview",
+  //       url: "/needs-assessment",
+  //     },
+  //     {
+  //       id: 3.2,
+  //       title: "Data Explorer",
+  //       url: "/needs-assessment",
+  //     },
+  //     {
+  //       id: 3.3,
+  //       title: "Methodology",
+  //       url: "/needs-assessment",
+  //     },
+  //   ],
+  // },
+  // {
+  //   id: 4,
+  //   title: "Regions",
+  //   url: "/regions",
+  //   isSubMenu: true,
+  //   subMenu: [
+  //     {
+  //       id: 4.1,
+  //       title: "Overview",
+  //       url: "/regions",
+  //     },
+  //     {
+  //       id: 4.2,
+  //       title: "USA",
+  //       url: "/regions",
+  //     },
+  //     {
+  //       id: 4.3,
+  //       title: "Europe",
+  //       url: "/regions",
+  //     },
+  //     {
+  //       id: 4.4,
+  //       title: "Middle East",
+  //       url: "/regions",
+  //     },
+  //   ],
+  // },
   {
     id: 5,
     title: "Resources",
@@ -76,8 +76,8 @@ export const links = [
     subMenu: [
       {
         id: 6.1,
-        title: "Overview",
-        url: "/tech",
+        title: "Open Source Explorers",
+        url: "/tech/open-source-explorers",
       },
     ],
   },


### PR DESCRIPTION
…tech's sub menu title from 'Overview' to 'Open Source Explorer's'

## What changed?
removed "Regions" and "Needs" links from navbar and replaced tech's sub menu link of "Overview" to "Open Source Explorer's".
<!-- include a link to a GitHub issue, if applicable -->

## How will this change be visible?
visible on navbar or `src/data/navBarLinks`
<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [x ] Manual tests (describe)
