### PR TITLE
Fix Links in Footer

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -94,7 +94,7 @@ const Footer = () => {
                   {column.links.map((link) => (
                     <Link
                       key={link.name}
-                      href="{link.link}"
+                      href={link.link}
                       className="hover:underline"
                     >
                       {link.name}


### PR DESCRIPTION
## What changed?
Fix for #567 - the attribute in the link was in quotes so it wasn't working properly. Removing it fixed the issue. Some of the links in the footer still don't work but only because they haven't been set in `constants.ts` yet. Updating that will fix them.

## How will this change be visible?
The links in the footer now point to the correct pages.

## How can you test this change?

- [ ] Automated tests
- [X] Manual tests (describe)

Clicking on the links in the footer will bring you to correct pages.
