### PR TITLE
Fix/569/Timeline Line

### DIFF
--- a/src/components/about-us/Timeline.tsx
+++ b/src/components/about-us/Timeline.tsx
@@ -145,11 +145,11 @@ export const Timeline: React.FC = () => {
                 <Box
                   asChild
                   position="absolute"
-                  top="5"
                   left={{ initial: "40px", sm: "50%" }}
                   width="2px"
+                  className="top-6 md:top-32"
                 >
-                  {/* top=5 (24px) accounts for both the top & bottom timeline markers
+                  {/* top-6 (24px) accounts for both the top & bottom timeline markers
                       being moved down via their top=3 (12px each)
                   */}
                   <Separator


### PR DESCRIPTION
## What changed?

#569 - Fixed blue line position on wider screens so that it reaches the final node.

## How will this change be visible?

The blue line now reaches the final node on wider screens. 

<img width="1429" height="1184" alt="Screenshot 2025-08-27 at 12 43 45 PM" src="https://github.com/user-attachments/assets/e84a4eb2-17a1-4984-af23-332f55d0715d" />

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (Checked to ensure alignment is correct at all breakpoints)
