### PR TITLE
fix/629/button height

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/donate/CampaignCard.tsx
+++ b/src/components/donate/CampaignCard.tsx
@@ -85,14 +85,18 @@ const CampaignCard: FC<Props> = forwardRef<HTMLDivElement, Props>(
             </Box>
             <Flex gap="2" wrap={"wrap"} mx="1" mb="3" mt="auto">
               <Box px="4" py="2" asChild>
-                <Button className="bg-navy-600 hover:bg-navy-500" asChild>
+                <Button
+                  className="bg-navy-600 hover:bg-navy-500"
+                  style={{ height: "44px" }}
+                  asChild
+                >
                   <Link href={donateLink} size="3">
                     Donate now
                   </Link>
                 </Button>
               </Box>
               <Box px="4" py="2" asChild>
-                <Button variant="soft" asChild>
+                <Button variant="soft" style={{ height: "44px" }} asChild>
                   <Link href={moreLink} size="3" className="no-underline">
                     More info
                   </Link>

--- a/src/components/donate/HeroSection.tsx
+++ b/src/components/donate/HeroSection.tsx
@@ -89,6 +89,7 @@ const HeroSection = () => {
                   <Button
                     className="bg-white text-black hover:bg-navy-500 hover:text-white transition-200"
                     size={{ initial: "3", sm: "2", md: "3" }}
+                    style={{ height: "44px" }}
                     asChild
                   >
                     <Link
@@ -104,6 +105,7 @@ const HeroSection = () => {
                   <Button
                     className=" bg-navy-600 hover:bg-navy-500"
                     size={{ initial: "3", sm: "2", md: "3" }}
+                    style={{ height: "44px" }}
                     asChild
                   >
                     <Link
@@ -119,6 +121,7 @@ const HeroSection = () => {
                   <Button
                     className="bg-navy-600 hover:bg-navy-500 "
                     size={{ initial: "3", sm: "2", md: "3" }}
+                    style={{ height: "44px" }}
                     asChild
                   >
                     <Link

--- a/src/components/resources/assort/ResourcesFooter.tsx
+++ b/src/components/resources/assort/ResourcesFooter.tsx
@@ -58,6 +58,9 @@ export const ResourcesFooter = () => {
                     mt="auto"
                     className="bg-navy-600 hover:bg-navy-500"
                     asChild
+                    style={{
+                      height: "44px",
+                    }}
                   >
                     <Link
                       href={item.link}


### PR DESCRIPTION
## What changed?

Set the height of buttons on the "donate" and "resource" pages to 44px.

## How will this change be visible?

Buttons on the resources page footer section, as well as the donate page hero and campaign grid sections are slightly bigger.

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (Checked that there were no layout issues caused by the size changes)
