### PR TITLE
Add copy section to /donate

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -1,12 +1,14 @@
 import DonateGrid from "@/components/donate/DonateGrid";
 import FUND_RAISERS from "@/data/donate.json";
 import HeroSection from "@/components/donate/HeroSection";
+import CopySection from "@/components/donate/CopySection";
 import DonateLandingText from "@/components/donate/DonateLandingText";
 
 const Page = () => {
   return (
     <>
       <HeroSection />
+      <CopySection />
       {FUND_RAISERS && FUND_RAISERS.length > 0 && (
         <DonateGrid funds={FUND_RAISERS} />
       )}

--- a/src/components/donate/CopySection.tsx
+++ b/src/components/donate/CopySection.tsx
@@ -1,0 +1,27 @@
+import { Box, Text } from "@radix-ui/themes";
+
+const CopySection = () => (
+  <Box
+    pt={{
+      initial: "90px",
+      sm: "80px",
+      md: "64px",
+    }}
+    pb="64px"
+    px={{
+      initial: "20px",
+      sm: "0",
+    }}
+    maxWidth={{ sm: "80%", md: "70%" }}
+    mx="auto"
+  >
+    <Text as="p" align={"center"} size={{ initial: "5", md: "6" }}>
+      Distribute Aid ensures every dollar and diaper donated is put to good use.
+      Our logistics management system reduces wasted items and shipping costs,
+      including carbon emissions, by significant margins. We don&apos;t pay our
+      executives lavish salaries, and we don&apos;t spend money on advertising.
+    </Text>
+  </Box>
+);
+
+export default CopySection;


### PR DESCRIPTION
## What changed?

Issue #627 - Added CopySection component with the copy specified in the issue. The copy section has been added to the /donate page below HeroSection.

## How will this change be visible?

Below the hero section, there is now a copy section with the additional copy.

<img width="2858" height="1340" alt="image" src="https://github.com/user-attachments/assets/4afb1b5d-b611-4d54-8767-e8ccb6c4e8d1" />


## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (Checked that copy is readable and formatted correctly on both mobile and desktop)
