### PR TITLE
HRT Page About the Project Component 

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/responses/hrt-toolkit/page.tsx
+++ b/src/app/responses/hrt-toolkit/page.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { HrtToolkitHero } from "@/components/responses/hrt-toolkit/HrtToolkitHero";
 import { GetInvolved } from "@/components/responses/hrt-toolkit/GetInvolved";
 import { HowItWorks } from "@/components/responses/hrt-toolkit/HowItWorks";
+import { AboutTheProject } from "@/components/responses/hrt-toolkit/AboutTheProject";
 
 const HrtToolkit: FC = () => {
   return (
@@ -9,6 +10,7 @@ const HrtToolkit: FC = () => {
       <HrtToolkitHero />
       <HowItWorks />
       <GetInvolved />
+      <AboutTheProject />
     </main>
   );
 };

--- a/src/components/responses/hrt-toolkit/AboutTheProject.tsx
+++ b/src/components/responses/hrt-toolkit/AboutTheProject.tsx
@@ -24,7 +24,8 @@ export const AboutTheProject: FC = () => (
 
           <Container
             px="24px"
-            maxWidth={{ sm: "calc(100% - 48px)", md: "calc(100% - 240px)" }}
+            mb="2"
+            maxWidth={{ sm: "calc(100% - 48px)", md: "calc(100% - 160px)" }}
           >
             <ul className="list-disc list-inside">
               {list_items?.map((item, index) => (

--- a/src/components/responses/hrt-toolkit/AboutTheProject.tsx
+++ b/src/components/responses/hrt-toolkit/AboutTheProject.tsx
@@ -1,0 +1,49 @@
+import { FC } from "react";
+import { Container, Flex, Heading, Section, Text } from "@radix-ui/themes";
+
+export const AboutTheProject: FC = () => (
+  <>
+    <Section position="relative" width="100%" size="1" className="bg-red-50">
+      <Container>
+        <Flex
+          width="100%"
+          direction="column"
+          align="center"
+          justify="center"
+          gap="5"
+        >
+          <Heading
+            as="h2"
+            size="7"
+            weight="bold"
+            align="center"
+            className="text-navy-800"
+          >
+            About The Project
+          </Heading>
+
+          <Container
+            px="24px"
+            maxWidth={{ sm: "calc(100% - 48px)", md: "calc(100% - 240px)" }}
+          >
+            <ul className="list-disc list-inside">
+              {list_items?.map((item, index) => (
+                <li className="text-xl" key={`about_the_project_li_${index}`}>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </Container>
+        </Flex>
+      </Container>
+    </Section>
+  </>
+);
+
+const list_items = [
+  "we don’t provide HRT but sundries needed to administer HRT safely for trans people who are often already in a precarious financial situation",
+  "harm reduction (needle sharing or reuse)",
+  "privacy for trans people in dangerous climate in US (needs better phrasing ofc)",
+  "using existing mutual aid networks",
+  "show $ impact made (based on production count) (?x multiplier)",
+];

--- a/src/stylesheets/text.css
+++ b/src/stylesheets/text.css
@@ -2,6 +2,10 @@
   @apply list-disc pl-10;
 }
 
+.list-inside ul {
+  list-style-position: inside;
+}
+
 .donate-icon--upper {
   transform: translate(-35%, -35%);
 }


### PR DESCRIPTION
## What changed?

<!-- include a link to a GitHub issue, if applicable -->
Closes #662 - adds the about-the-project section and fills with the placeholder copy from designs

## How will this change be visible?

<!-- pages, components, etc. -->
Visible at top of the hrt-toolkit page at `/responses/hrt-toolkit`

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (describe)

<img width="1149" height="301" alt="Screenshot 2025-09-09 at 9 51 38 PM" src="https://github.com/user-attachments/assets/df56757a-57a7-43e1-85ba-a5470645dd59" />
