### PR TITLE
Creates Get Involved component

### DIFF
--- a/src/app/responses/hrt-toolkit/page.tsx
+++ b/src/app/responses/hrt-toolkit/page.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
 import { HrtToolkitHero } from "@/components/responses/hrt-toolkit/HrtToolkitHero";
+import { GetInvolved } from "@/components/responses/hrt-toolkit/GetInvolved";
 import { HowItWorks } from "@/components/responses/hrt-toolkit/HowItWorks";
 
 const HrtToolkit: FC = () => {
@@ -7,6 +8,7 @@ const HrtToolkit: FC = () => {
     <main>
       <HrtToolkitHero />
       <HowItWorks />
+      <GetInvolved />
     </main>
   );
 };

--- a/src/components/responses/hrt-toolkit/GetInvolved.tsx
+++ b/src/components/responses/hrt-toolkit/GetInvolved.tsx
@@ -1,0 +1,69 @@
+import { FC, ReactNode } from "react";
+import { Button, Heading, Section, Text } from "@radix-ui/themes";
+import Image, { StaticImageData } from "next/image";
+import fortPickett from "../../../../public/images/home/fort-pickett.jpg";
+
+export const GetInvolved: FC = () => {
+  return (
+    <>
+      <Section>
+        <Heading as="h2" align="center" className="text-navy-800 mb-8" size="8">
+          How To Get Involved
+        </Heading>
+
+        <div className="flex justify-center flex-wrap">
+          <GetInvolvedBox
+            title="Frontline Groups"
+            image={fortPickett}
+            buttonText="Sign up for the waitlist"
+          >
+            This is the information for frontline groups. Lorem ipsum dolor sit
+            amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+            nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit
+            esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+            cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </GetInvolvedBox>
+          <GetInvolvedBox
+            title="In-kind Donations"
+            image={fortPickett}
+            buttonText="Reach out to donate in kind"
+          >
+            This is the information for in-kind donations.
+          </GetInvolvedBox>
+        </div>
+      </Section>
+    </>
+  );
+};
+
+type GetInvolvedBoxType = {
+  buttonText: string;
+  children?: ReactNode;
+  image: StaticImageData;
+  title: string;
+};
+
+const GetInvolvedBox: FC<GetInvolvedBoxType> = ({
+  buttonText,
+  children,
+  image,
+  title,
+}) => (
+  <div className="get-involved bg-navy-300 rounded-md m-4 w-full md:w-1/3">
+    <Image src={image} className="w-full h-auto rounded-t-md" alt={title} />
+    <div className="p-5">
+      <div className="mb-4">
+        <Text size="7" className="uppercase text-navy-800 mb-6 font-bold">
+          {title}
+        </Text>
+      </div>
+      <div className="font-bold mb-2">{children}</div>
+      <Button size="2" mt="auto" className="bg-navy-600 hover:bg-navy-500 p-2">
+        {buttonText}
+      </Button>
+    </div>
+  </div>
+);


### PR DESCRIPTION
## What changed?
Closes [#664](https://github.com/distributeaid/next-website-v2/issues/664). Adds the component for "Get Involved" to the hrt toolkit page. It's currently got placeholder texts and images and the buttons at the bottom each of the boxes don't do anything, but they're ready to be set up when that's ready.

I recreated the branch and made a new PR to try and get around the `This branch cannot be rebased due to conflicts` issue on PR #686

## How will this change be visible?
Desktop
<img width="2566" height="1659" alt="Screenshot from 2025-09-17 11-22-03" src="https://github.com/user-attachments/assets/882d9e70-b007-4c41-be3f-ffd29f34bd72" />

Mobile
<img width="744" height="1421" alt="Screenshot from 2025-09-17 11-22-31" src="https://github.com/user-attachments/assets/bb47441c-22ce-4bb8-8dcb-4fa81591eb12" />

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (describe)