### PR TITLE
docs: make 'About the Project' the first section in README'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# About Distribute Aid
+## About the Project
 
-Distribute Aid is a grassroots-to-grassroots humanitarian aid organization.
+This repository contains the scaffolding for DA's new website, powered by Nextjs, TypeScript & Strapi.
 
-Founded in 2019, we coordinate relief shipments and manage logistics for disaster response efforts around the world. Our open-source tools and a committed team of volunteers allow us to deliver more aid for less money, while also minimizing waste and emissions.
 
 ## Table of Contents
 
-- [About Distribute Aid](#about-distribute-aid)
 - [About Project](#about-the-project)
 - [Technologies Used](#technologies-used)
 - [Getting started](#-getting-started-with-gitpod)
@@ -24,9 +22,7 @@ Founded in 2019, we coordinate relief shipments and manage logistics for disaste
 - [Reviewing Pull Requests](#reviewing-pull-requests)
 - [Merging Branches](#merging-branches)
 
-## About the Project
 
-This repository contains the scaffolding for DA's new website, powered by Nextjs, TypeScript & Strapi.
 
 ## Technologies Used
 


### PR DESCRIPTION
## What changed?
Replaced the first section of `README.md` with `About the Project`, followed by `Table of Contents`. Fixes #659 
<!-- include a link to a GitHub issue, if applicable -->

## How will this change be visible?
Removed `About Distribute Aid` section. 
<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
