### PR TITLE
Updated copy in Where We Work section

### DIFF
--- a/src/components/home/WhereWeWork.tsx
+++ b/src/components/home/WhereWeWork.tsx
@@ -35,20 +35,22 @@ const WhereWeWork = () => {
     {
       map: europeMap,
       title: "Europe",
-      summary: "Refugee populations across the Mediterranean and Balkans.",
+      summary:
+        "In Europe, we work with local grassroots organizers who support people on the move, asylum seekers, houseless and low-income people, and those displaced due to war or disaster. Our partners provide support ranging from medical services, legal support, advocacy, hot meals, and NFI distributions.",
       alt: `Color-coded map of Europe showing three aid-flow categories. Receiving aid: France, Croatia, Bosnia & Herzegovina, Serbia, Romania, Moldova. Sending aid: Spain, United Kingdom, Norway, Austria, Hungary, Lithuania. Both: Netherlands, Germany, Poland, Italy, Ukraine, Greece.`,
     },
     {
       map: middleEastMap,
       title: "The Middle East",
-      summary: "Survivors of conflict and displacement in the Levant regions.",
+      summary:
+        "In the Middle East, our partners are primarily situated in the Levant region. There, we work with organisations providing educational support, employment opportunities, medical services and infrastructure, and shelter for refugees.",
       alt: `Color-coded map of The Middle East showing a single aid-flow category. Sending aid: Lebanon, Gaza, West Bank, Jordan.`,
     },
     {
       map: unitedStatesMap,
       title: "USA",
       summary:
-        "Vulnerable communities facing disasters both natural and manmade.",
+        "In the US, our work is primarily centered around disaster relief and pre-positioning aid to be able to act swiftly when disaster strikes. We have a large network of partners and warehouses in disaster-prone areas who work locally with mutual aid in their communities.",
       alt: `Color-coded map of the continental United States showing three aid-flow categories. Receiving aid: Washington, Utah, New York, Delaware. Sending aid: Oregon, Texas, Indiana, Ohio, Tennessee, Florida. Both: California, Georgia, North Carolina, Pennsylvania.`,
     },
   ];


### PR DESCRIPTION
## What changed?

Closes #816

Change to updated copy to "Where We Work".

## How will this change be visible?

Copy in the "Where We Work" section reflects changes outlined in the related issue.

## How can you test this change?

- [ ] Manual tests (Check that all map card components are still equal height)
