### PR TITLE
content: 2 column footer links

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,5 +1,6 @@
 import { RiInstagramFill, RiBlueskyFill, RiLinkedinFill } from "react-icons/ri";
 import Home from "@/app/page";
+import { Title } from "@radix-ui/themes/dist/cjs/components/alert-dialog";
 
 export const MONTHS = [
   "January",
@@ -297,7 +298,16 @@ export const SOCIAL_LINKS = [
   },
 ];
 
-export const FOOTER_COLUMNS = [
+export interface FooterColumn {
+  title: string;
+  links: {
+    name: string;
+    link: string;
+    external?: boolean;
+  }[];
+}
+
+export const FOOTER_COLUMNS: FooterColumn[] = [
   {
     title: "",
     links: [
@@ -306,20 +316,16 @@ export const FOOTER_COLUMNS = [
         link: "/",
       },
       {
-        name: "About us",
+        name: "About Us",
         link: "/about-us",
-      },
-      {
-        name: "Team",
-        link: "/team",
-      },
-      {
-        name: "Tech",
-        link: "/tech",
       },
       {
         name: "Donate",
         link: "/donate",
+      },
+      {
+        name: "Team",
+        link: "/team",
       },
       {
         name: "Contact",
@@ -329,6 +335,23 @@ export const FOOTER_COLUMNS = [
         name: "Newsletter",
         link: "https://distribute-aid.beehiiv.com/",
         external: true,
+      },
+    ],
+  },
+  {
+    title: "",
+    links: [
+      {
+        name: "Tech",
+        link: "/tech",
+      },
+      {
+        name: "Resources",
+        link: "/resources/assort",
+      },
+      {
+        name: "HRT Harm Reduction Toolkit",
+        link: "/responses/hrt-toolkit",
       },
     ],
   },


### PR DESCRIPTION
## What changed?

Closes #832

Splits footer links into 2 columns and adds links to Resources and HRT Harm Reduction Toolkit pages. Also added a TypeScript interface for footer columns.

## How will this change be visible?

Is visible in the footer on each page, there are now 2 columns of links instead of 1, and the Resources and HRT Harm Reduction Toolkit links have been added.

<img width="3218" height="672" alt="image" src="https://github.com/user-attachments/assets/c8e3d0ff-2df5-4e6e-8c28-15e259d6e4ae" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
