### PR TITLE
Fix/Newsletter Signup 

### DIFF
--- a/src/components/home/GetInvolved.tsx
+++ b/src/components/home/GetInvolved.tsx
@@ -15,7 +15,7 @@ import { handleNewsletterSignup } from "@/utils/newsletter";
 
 const GetInvolved = () => {
   const emailInputRef = useRef<HTMLInputElement>(null);
-  const [newsletterSuccess, setNewsletterSuccess] = useState(true);
+  const [newsletterSuccess, setNewsletterSuccess] = useState(false);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## What changed?

Set initial signup success state from true to false.

## How will this change be visible?

Success message will not display on newsletter signup until form is submitted and gets a success response. 

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
