### PR TITLE
Fix/Two Children With Same Key

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -137,8 +137,8 @@ const Footer = () => {
               gap={{ initial: "9" }}
               direction={{ initial: "row" }}
             >
-              {FOOTER_COLUMNS.map((column) => (
-                <Flex key={column.title || "main"} direction="column" gap="3">
+              {FOOTER_COLUMNS.map((column, index) => (
+                <Flex key={`column-${index + 1}`} direction="column" gap="3">
                   {column.title && (
                     <ColumnHeading>{column.title}</ColumnHeading>
                   )}


### PR DESCRIPTION
## What changed?

Closes #856 

Updates footer to use index instead of column name for key. The related problem in HeroSection.tsx should be resolved by issue #855

## How will this change be visible?

Related error will no longer appear in dev

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
