### PR TITLE
Fix "Our Impact" icons

### DIFF
--- a/src/components/impact-card/ImpactCard.tsx
+++ b/src/components/impact-card/ImpactCard.tsx
@@ -24,10 +24,9 @@ const ImpactCard: React.FC<ImpactCardProps> = ({
       <Flex
         width="100%"
         height="100%"
-        className="bg-navy-200 rounded-lg px-10 pb-10 pt-16"
+        className="bg-navy-200 rounded-lg p-10"
         direction="column"
-        gap="8"
-        justify="end"
+        justify="between"
       >
         <Flex align="center" justify="center" gap="5">
           <span aria-hidden="true">
@@ -50,6 +49,7 @@ const ImpactCard: React.FC<ImpactCardProps> = ({
           weight="regular"
           size={{ initial: "6", md: "6", lg: "8" }}
           align="center"
+          // wrap="nowrap"
         >
           {label}
         </Heading>


### PR DESCRIPTION
## What changed?

Closes #873

When labels wrap to a second line, the icon will no longer be pushed out of bounds.

<img width="455" height="285" alt="image" src="https://github.com/user-attachments/assets/bfe8eb4d-21c9-4b89-98aa-ef589a23912e" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (test to ensure icon does not go out of bounds when resizing window)
