### PR TITLE
fix: Updates README to have a project specific header section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This repository contains the scaffolding for DA's new website, powered by Nextjs
 - [Reviewing Pull Requests](#reviewing-pull-requests)
 - [Merging Branches](#merging-branches)
 
-
 ## Technologies Used
 
 - [Nextjs](https://nextjs.org/docs) - Frontendframework


### PR DESCRIPTION
## What changed?

Updated the project readme to have a project-specific first section, replacing the DA info section that's there now. Fixes https://github.com/distributeaid/next-website-v2/issues/659

## How will this change be visible?

Updated README page

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
