### PR TITLE
fix/735/Tech Page Markdown

### DIFF
--- a/src/components/tech/WorkingBox.tsx
+++ b/src/components/tech/WorkingBox.tsx
@@ -1,5 +1,6 @@
 import { Badge, Box, Container, Flex, Heading, Text } from "@radix-ui/themes";
 import SmartLink from "../link/SmartLink";
+import { MarkdownContent } from "../markdown/MarkdownContent";
 
 interface WorkingBoxProps {
   title: string;
@@ -39,16 +40,18 @@ export const WorkingBox = ({
         >
           {title}
         </Heading>
-        <Text
-          as="p"
-          size={{ initial: "3", sm: "5" }}
-          className="sm:leading-[2]"
-        >
-          {para} <br />
-          <SmartLink href={link} className="text-navy-800 underline">
-            {linklabel}
-          </SmartLink>
-        </Text>
+        <MarkdownContent
+          content={para}
+          wrapper={(children) => (
+            <Text size={{ initial: "3", sm: "5" }} className="sm:leading-[2]">
+              {children}
+              <SmartLink href={link} className="text-navy-800 underline">
+                {linklabel}
+              </SmartLink>
+            </Text>
+          )}
+        />
+
         <Box>
           {tech.map((item, index) => {
             return (


### PR DESCRIPTION
## What changed?

Closes #735 

Wraps text in `WorkingBox.tsx` in MarkdownContent component.

## How will this change be visible?

Should look exactly the same as before, but will render Markdown syntax when used.

<img width="974" height="982" alt="image" src="https://github.com/user-attachments/assets/18b8b6d9-85f3-4eb8-b3db-bacf408f8e6a" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
