### PR TITLE
ci/shifting-codeowners-to-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @ghall89 @finnporter
+* @distributeaid/reviews-website


### PR DESCRIPTION
## What changed?
After checking the Docs repository, I have realized some review teams were already established, so I'm shifting the CodeOwners to use them.
<!-- include a link to a GitHub issue, if applicable -->

## How will this change be visible?

<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
