### PR TITLE
Updates nav items to use 'normal' font weight to match mocks

### DIFF
--- a/src/components/nav/mobileNavBar.tsx
+++ b/src/components/nav/mobileNavBar.tsx
@@ -30,7 +30,7 @@ const MobileNavBar = () => {
             <Accordion.Item
               key={title}
               value={title}
-              className="font-medium py-4 "
+              className="font-normal py-4 "
             >
               {isSubMenu ? (
                 <Accordion.Header>
@@ -110,7 +110,7 @@ const MobileNavBar = () => {
         width={"100%"}
         justify={"center"}
         p={"2"}
-        className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-medium cursor-pointer rounded-lg"
+        className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-normal cursor-pointer rounded-lg"
       >
         <NavigationMenu.Item>
           <NavigationMenu.Link href="/donate" target="" rel="noreferrer">

--- a/src/components/nav/navBar.tsx
+++ b/src/components/nav/navBar.tsx
@@ -82,7 +82,7 @@ const NavBar = () => {
               {links.map(({ title, url, isSubMenu, subMenu }) => (
                 <NavigationMenu.Item
                   className={cx(
-                    "font-medium  decoration-2 underline-offset-8 duration-200",
+                    "font-normal  decoration-2 underline-offset-8 duration-200",
                     {
                       "hover:underline": title !== "Donate",
                       "hover:bg-navy-500 decoration-none cursor-pointer hover:text-white duration-200 text-dark-blue bg-white rounded-lg py-3 px-6 ":
@@ -94,7 +94,7 @@ const NavBar = () => {
                   {isSubMenu ? (
                     <Box className="group">
                       <Flex
-                        className="font-medium"
+                        className="font-normal"
                         position={"relative"}
                         align={"center"}
                         asChild
@@ -158,7 +158,7 @@ const NavBar = () => {
                   asChild
                   px={"5"}
                   py={"3"}
-                  className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-medium rounded-lg"
+                  className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-normal rounded-lg"
                 >
                   <Link href="/donate" rel="noreferrer">
                     Donate


### PR DESCRIPTION

<img width="981" height="234" alt="Screenshot 2026-02-10 at 7 53 15 PM" src="https://github.com/user-attachments/assets/d195c3b3-ff1a-4fc3-9462-2d678aa2af58" />
## What changed?

Updated nav item font weights per https://github.com/distributeaid/next-website-v2/issues/579

## How will this change be visible?

User-visible font weight changes

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests: confirming change via local development
