### PR TITLE
feat: add yarn all script to run all checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check:format": "yarn prettier --check .",
     "format": "yarn prettier --write .",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "all": "yarn check:types && yarn check:format && yarn lint && yarn test"
   },
   "dependencies": {
     "@beehiiv/sdk": "^0.1.9",


### PR DESCRIPTION
## What was done

Added a new `yarn all` script in `package.json` to run all project checks in a single command.

## Details

The script reuses the existing check scripts (`check:types`, `check:format`, `lint`, `test`) to maintain consistency and avoid duplication.

## Why

This makes it easier to run all checks locally before committing or opening a PR.

<img width="1174" height="960" alt="Screenshot 2026-02-13 233322" src="https://github.com/user-attachments/assets/318e124d-b80d-4edd-8a17-ec9341e2ca6e" />


Closes #962
