### PR TITLE
adds .env.example file with vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# newsletter
+BEHIIV_TOKEN=12345
+BEHIIV_PUB_KEY=12345
+
+# contact form
+RESEND_API_KEY=12345
+CONTACT_TO_EMAIL=test@test.com
+CONTACT_FROM_EMAIL=test@test.com


### PR DESCRIPTION
## What changed?

[Github issue](https://github.com/distributeaid/next-website-v2/issues/980)
I didn't need to add `.env.local` to the `.gitignore` file since it was already added.

## How will this change be visible?

This affects the _subscribe to newsletter_ widget and the _contact us_ page. In the dev environment, functionality will continue to fail since we do not have test environments and test tokens set up (AFAIK).

## How can you test this change?

No test are available yet.
