### PR TITLE
Remove nearly duplicate utility function

### DIFF
--- a/src/utils/site-theme.ts
+++ b/src/utils/site-theme.ts
@@ -9,47 +9,16 @@ export function getThemeLargeScreenWidth(): number {
 }
 
 let backgroundColorIndex = 0;
-const colors = shuffle(
-  getColors({
-    swatches: ["navy", "purple", "rosemary", "turquoise", "beige"],
-    weights: [50, 100],
-  }),
-);
+const colors = getVisualizationColors({
+  swatches: ["navy", "purple", "rosemary", "turquoise", "beige"],
+  weights: [50, 100],
+  randomize: true,
+});
 
 export function getBackgroundColor(): string {
   const color = colors[backgroundColorIndex];
   backgroundColorIndex = (backgroundColorIndex + 1) % colors.length;
   return color;
-}
-
-export function getColors({
-  swatches,
-  weights,
-}: {
-  swatches: string[];
-  weights: number[];
-}): string[] {
-  const themeColors = theme?.colors as unknown as Record<
-    string,
-    Record<number, string>
-  >;
-
-  const colors: string[] = [];
-  if (!themeColors) return colors;
-
-  for (const swatch of swatches) {
-    const swatchColors = themeColors[swatch];
-    if (!swatchColors) continue;
-
-    for (const weight of weights) {
-      const color = swatchColors[weight];
-      if (color) {
-        colors.push(color);
-      }
-    }
-  }
-
-  return colors;
 }
 
 export function getVisualizationColors({
@@ -81,11 +50,7 @@ export function getVisualizationColors({
     }
   }
 
-  if (randomize) {
-    colors.sort(() => Math.random() - 0.5);
-  }
-
-  return colors;
+  return randomize ? shuffle(colors) : colors;
 }
 
 // Utility function to shuffle an array


### PR DESCRIPTION
## What changed?

<!-- include a link to a GitHub issue, if applicable -->
Closes #976.

- Removed less capable function `getColors`.
- Also updated `getVisualizationColors` to use `shuffle` instead of randomizing with `.sort()`.

## How will this change be visible?
Should not be visible.

<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)
