### PR TITLE
feat/974/remove-hardcoded-production-url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ CONTACT_FROM_EMAIL=test@test.com
 # bank details
 IBAN="XXXX XXXX XXXX XXXX"
 BIC=XXXXXXXXXXX
+
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/src/components/link/SmartLink.tsx
+++ b/src/components/link/SmartLink.tsx
@@ -2,7 +2,7 @@ import { AnchorHTMLAttributes, FC } from "react";
 import ExternalLink from "./ExternalLink";
 import InternalLink from "./InternalLink";
 
-import { originsMatch } from "../../utils/url";
+import { getBaseURL, originsMatch } from "../../utils/url";
 
 const SmartLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
   href = "/",
@@ -10,7 +10,7 @@ const SmartLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
 }) => {
   const useInternalLink =
     //  href.startsWith('/') || originsMatch(href, window.location.origin)
-    href.startsWith("/") || originsMatch(href, "https://distributeaid.org");
+    href.startsWith("/") || originsMatch(href, getBaseURL());
 
   if (useInternalLink) {
     return <InternalLink to={href} {...props} />;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,10 @@
 export function getBaseURL(): URL {
   // HACK: made prod build
   //  return new URL('/', window.location.origin)
-  return new URL("/", "https://distributeaid.org");
+  return new URL(
+    "/",
+    process.env.NEXT_PUBLIC_BASE_URL ?? "https://distributeaid.org",
+  );
 }
 
 export function originsMatch(


### PR DESCRIPTION
## What changed?

Fixes #974
<!-- include a link to a GitHub issue, if applicable -->
Replaced hardcoded URL: `https://distributeaid.org` to use env variable instead.

## How will this change be visible?
N/A

## How can you test this change?
- [x] Manual tests (describe)
In different environments (`prod`/`staging` etc), set `NEXT_PUBLIC_BASE_URL` env variable to the appropriate URL in your hosting environment. Inspect requests in browser dev tools to verify correct URL is being used depending on the environment.