### PR TITLE
fix/1027/replace-hamburger-menu-toggle-div-with- a-button

### DIFF
--- a/src/components/nav/navBar.tsx
+++ b/src/components/nav/navBar.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { FaBars, FaChevronDown, FaTimes } from "react-icons/fa";
 import LogoMark from "../../../public/images/LogoMark";
 import * as NavigationMenu from "@radix-ui/react-navigation-menu";
-import { Box, Flex, Button } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import { SOCIAL_LINKS } from "@/data/constants";
 import Image from "next/image";
 import cx from "classnames";
@@ -167,7 +167,7 @@ const NavBar = () => {
                 </Box>
               )}
               {/* Hamburger Icon */}
-              <Button
+              <button
                 className="text-white z-40 cursor-pointer bg-transparent border-none"
                 onClick={() => setNav(!nav)}
                 aria-label={
@@ -181,7 +181,7 @@ const NavBar = () => {
                 ) : (
                   <FaBars size={30} aria-hidden="true" />
                 )}
-              </Button>
+              </button>
             </Flex>
             {/* Mobile Menu */}
             {nav && <MobileNavBar />}


### PR DESCRIPTION
Fixes #1027

## What changed?
Replaced hamburger menu toggle, a `div` originally, with a native HTML `Button`.. Verified that functionality is preserved.

## How will this change be visible?
No visible change in the UI. N/A

## How can you test this change?
- [x] Manual tests (describe)
Open up browser dev tools. Inspect the rendered elements to ensure the newly added `aria, classname, id` attributes are shown.