### PR TITLE
fix/1028/resolve-invalid-<a>-wrapping-inside-button

### DIFF
--- a/src/components/ui/GetInvolved.tsx
+++ b/src/components/ui/GetInvolved.tsx
@@ -74,7 +74,7 @@ const GetInvolved = () => {
                   <Text weight="medium" size="8">
                     {label}
                   </Text>
-                  <Button size="3">
+                  <Button size="3" asChild>
                     <a href={href}>{buttonLabel ?? label}</a>
                   </Button>
                 </Flex>


### PR DESCRIPTION
Fixes #1028

## What changed?

In the "Get Involved" section, each card's call-to-action is implemented as a Radix `<Button>` that wraps an `<a>` tag. Used `asChild` attribute in `<Button>` to render the  `<a>` directly without any nesting.

## How will this change be visible?
N/A

## How can you test this change?
- [x] Manual tests (describe)
Open browser dev tools, inspect the necessary elements in the DOM to ensure `<a>` tags are rendered directly without any wrapping inside a `Button`.