### PR TITLE
fix/1030/correct-logistic-to-logistics-in-hero-heading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ const Home = () => {
   return (
     <main>
       <HeroSection
-        heading="Your Mutual Aid Logistic
+        heading="Your Mutual Aid Logistics
         Experts"
         imgSrc="/images/photos/photo-grc-moria-fire-relief.jpg"
         imgAlt="hero image"


### PR DESCRIPTION
Fixes #1030

## Summary
- Fixed typo in homepage H1: "Your Mutual Aid Logistic Experts" → "Your Mutual Aid Logistics Experts"
- "Logistics" is the correct noun form

Closes #1030