### PR TITLE
fix: correct 'Logistic' typo to 'Logistics' in hero heading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ const Home = () => {
   return (
     <main>
       <HeroSection
-        heading="Your Mutual Aid Logistic
+        heading="Your Mutual Aid Logistics
         Experts"
         imgSrc="/images/photos/photo-grc-moria-fire-relief.jpg"
         imgAlt="hero image"


### PR DESCRIPTION
## Summary
- Fixes typo in homepage hero heading: "Your Mutual Aid Logistic Experts" → "Your Mutual Aid Logistics Experts"

Closes #1030

## Test plan
- [ ] Verify the homepage hero heading displays "Your Mutual Aid Logistics Experts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)