### PR TITLE
fix: typo "Mutual Aid Logistic" to "Logistics" (#1030)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ const Home = () => {
   return (
     <main>
       <HeroSection
-        heading="Your Mutual Aid Logistic
+        heading="Your Mutual Aid Logistics
         Experts"
         imgSrc="/images/photos/photo-grc-moria-fire-relief.jpg"
         imgAlt="hero image"


### PR DESCRIPTION
Fixed a minor typo in the heading on the homepage as requested in issue #1030.