### PR TITLE
fix: correct typo "Logistic" → "Logistics" in hero heading

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ const Home = () => {
   return (
     <main>
       <HeroSection
-        heading="Your Mutual Aid Logistic
+        heading="Your Mutual Aid Logistics
         Experts"
         imgSrc="/images/photos/photo-grc-moria-fire-relief.jpg"
         imgAlt="hero image"


### PR DESCRIPTION
## Summary
- Fixed typo in homepage H1 heading: "Logistic" → "Logistics"
- "Logistics" is the correct noun form; "Logistic" is an adjective

Closes #1030

## Test plan
- [ ] Visit homepage and verify heading reads "Your Mutual Aid Logistics Experts"