### PR TITLE
fix: remove duplicate newsletter-signup ID

### DIFF
--- a/src/components/ui/GetInvolved.tsx
+++ b/src/components/ui/GetInvolved.tsx
@@ -85,7 +85,7 @@ const GetInvolved = () => {
       </Grid>
 
       <Box className="bg-fuchsia-100" id="newsletter-signup">
-        <Box id="newsletter-signup" py="8" px="4" maxWidth="1242px" mx="auto">
+        <Box py="8" px="4" maxWidth="1242px" mx="auto">
           <Heading as="h3" size="8">
             Stay Connected With Distribute Aid
           </Heading>


### PR DESCRIPTION
## Summary

Removes the duplicate `id="newsletter-signup"` from the inner `<Box>` element in `GetInvolved.tsx`.

**Before:** Both the outer and inner `<Box>` elements had `id="newsletter-signup"`, which is invalid HTML (IDs must be unique) and can cause accessibility issues with screen readers and anchor links.

**After:** Only the outer `<Box>` retains the ID. The inner `<Box>` keeps all its other props unchanged.

## Changes

- `src/components/ui/GetInvolved.tsx` — removed `id="newsletter-signup"` from inner Box (line 88)

Fixes #1029