### PR TITLE
fix/1076/ambiguous wording in 'where we work'

### DIFF
--- a/src/components/home/WhereWeWork.tsx
+++ b/src/components/home/WhereWeWork.tsx
@@ -16,12 +16,12 @@ import { SectionHeading } from "../ui/SectionWithTitle";
 const WhereWeWork = () => {
   const mapKey: MapKey[] = [
     {
-      label: "Receiving Aid",
-      color: "bg-key-dark-blue",
+      label: "Sending Aid From",
+      color: "bg-key-light-blue",
     },
     {
-      label: "Sending Aid",
-      color: "bg-key-light-blue",
+      label: "Receiving Aid",
+      color: "bg-key-dark-blue",
     },
     {
       label: "Both",
@@ -34,7 +34,7 @@ const WhereWeWork = () => {
   return (
     <Section className="bg-slate-100 p-12" aria-labelledby={headingId}>
       <Box mb="9">
-        <SectionHeading id={headingId}>Where We Work</SectionHeading>
+        <SectionHeading id={headingId}>Global Aid Network</SectionHeading>
         <Flex gap="6" justify="center" mt="5" asChild>
           <ul>
             {mapKey.map(({ label, color }) => (


### PR DESCRIPTION
Fixes #1076

## What changed?

Changed "Where We Work" to "Global Aid Network", moved "Sending Aid" to the first item and changed the label to "Sending Aid From"

## How will this change be visible?

<img width="1438" height="580" alt="image" src="https://github.com/user-attachments/assets/8e15f7d1-4719-497a-a170-49ec427f475c" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)