### PR TITLE
feat/1082/implement GitHub actions deployment and SOPS env files

### DIFF
--- a/.environments/.sops.yaml
+++ b/.environments/.sops.yaml
@@ -9,4 +9,4 @@ creation_rules:
           # Finn's key
           - age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
           # Graham's key
-          - age1zzr7w9eefkgevmv4k4s0uncl5lkff48gjde4rmt0pqr8z278r9zspqrx3q
+          - age1mzmws9mpksrk7chzxwrg570x77gjdsspswpzuta9q38fy7a57f5q0ks5x4

--- a/.environments/.sops.yaml
+++ b/.environments/.sops.yaml
@@ -8,3 +8,5 @@ creation_rules:
           - age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
           # Finn's key
           - age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
+          # Graham's key
+          - age1zzr7w9eefkgevmv4k4s0uncl5lkff48gjde4rmt0pqr8z278r9zspqrx3q

--- a/.environments/.sops.yaml
+++ b/.environments/.sops.yaml
@@ -1,0 +1,10 @@
+creation_rules:
+  - path_regex: \.enc\.yaml$
+    key_groups:
+      - age:
+          # CI Key
+          - age18czeejgx4sqes9lulh02af08z39u98lsm7dcuprk2y5yag43uegskuuhff
+          # Jaime's key
+          - age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
+          # Finn's key
+          - age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y

--- a/.environments/README.md
+++ b/.environments/README.md
@@ -38,32 +38,6 @@ Store your age private key at:
 | macOS / Linux | `~/.config/sops/age/keys.txt` |
 | Windows       | `%AppData%\sops\age\keys.txt` |
 
-## Editing secrets
-
-```sh
-sops .environments/staging.secrets.enc.yaml
-```
-
-SOPS decrypts the file, opens it in your editor, and re-encrypts on save.
-
-## Getting access
-
-Generate an age key pair and share the public key with someone who already has access:
-
-**macOS / Linux**
-
-```sh
-age-keygen -o ~/.config/sops/age/keys.txt
-```
-
-**Windows** (PowerShell)
-
-```powershell
-age-keygen -o "$env:AppData\sops\age\keys.txt"
-```
-
-`age-keygen` prints your public key (`age1...`) to stdout. Share that value, not the file.
-
 ## Granting access
 
 1. Add the new public key to `.sops.yaml` under the `age` list in the relevant `key_groups` entry:
@@ -98,3 +72,31 @@ age-keygen -o "$env:AppData\sops\age\keys.txt"
    ```
 3. Commit the changes.
 4. Rotate any secrets they had access to, as re-encrypting does not invalidate what was previously decrypted.
+
+## Editing secrets
+
+```sh
+sops staging.secrets.enc.yaml
+```
+
+SOPS decrypts the file, opens it in your editor, and re-encrypts on save. Remember to run the command from within the .environments folder!
+
+## Getting access
+
+Generate an age key pair and share the public key with someone who already has access:
+
+**macOS / Linux**
+
+```sh
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+**Windows** (PowerShell)
+
+```powershell
+age-keygen -o "$env:AppData\sops\age\keys.txt"
+```
+
+`age-keygen` prints your public key (`age1...`) to stdout. Share that value, not the file.
+
+

--- a/.environments/README.md
+++ b/.environments/README.md
@@ -33,10 +33,12 @@ winget install --id=FiloSottile.age -e
 
 Store your age private key at:
 
-| OS            | Path                          |
-| ------------- | ----------------------------- |
-| macOS / Linux | `~/.config/sops/age/keys.txt` |
-| Windows       | `%AppData%\sops\age\keys.txt` |
+| OS      | Path                                                 |
+| ------- | ---------------------------------------------------- |
+| macOS   | `~/Library/Application Support/sops/age/keys.txt`    |
+| Linux   | `~/.config/sops/age/keys.txt`                        |
+| Windows | `%AppData%\sops\age\keys.txt`                        |
+
 
 ## Granting access
 
@@ -85,9 +87,17 @@ SOPS decrypts the file, opens it in your editor, and re-encrypts on save. Rememb
 
 Generate an age key pair and share the public key with someone who already has access:
 
-**macOS / Linux**
+**macOS**
 
 ```sh
+mkdir -p "$HOME/Library/Application Support/sops/age"
+age-keygen -o "$HOME/Library/Application Support/sops/age/keys.txt"
+```
+
+**Linux**
+
+```sh
+mkdir -p ~/.config/sops/age
 age-keygen -o ~/.config/sops/age/keys.txt
 ```
 

--- a/.environments/README.md
+++ b/.environments/README.md
@@ -1,0 +1,100 @@
+# Secrets
+
+App secrets are stored as SOPS-encrypted YAML files in this directory. Each environment has its own file (`staging.secrets.enc.yaml`, etc.). Secrets are decrypted at deploy time by CI.
+
+## Prerequisites
+
+Install [sops](https://github.com/getsops/sops) and [age](https://github.com/FiloSottile/age):
+
+**macOS**
+
+```sh
+brew install sops age
+```
+
+**Linux**
+
+```sh
+# sops: download the binary for your architecture from
+# https://github.com/getsops/sops/releases/latest
+
+# age
+sudo apt install age        # Debian/Ubuntu
+sudo dnf install age        # Fedora
+sudo pacman -S age          # Arch
+```
+
+**Windows** (PowerShell)
+
+```powershell
+winget install --id=mozilla.sops -e
+winget install --id=FiloSottile.age -e
+```
+
+Store your age private key at:
+
+| OS            | Path                          |
+| ------------- | ----------------------------- |
+| macOS / Linux | `~/.config/sops/age/keys.txt` |
+| Windows       | `%AppData%\sops\age\keys.txt` |
+
+## Editing secrets
+
+```sh
+sops .environments/staging.secrets.enc.yaml
+```
+
+SOPS decrypts the file, opens it in your editor, and re-encrypts on save.
+
+## Getting access
+
+Generate an age key pair and share the public key with someone who already has access:
+
+**macOS / Linux**
+
+```sh
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+**Windows** (PowerShell)
+
+```powershell
+age-keygen -o "$env:AppData\sops\age\keys.txt"
+```
+
+`age-keygen` prints your public key (`age1...`) to stdout. Share that value, not the file.
+
+## Granting access
+
+1. Add the new public key to `.sops.yaml` under the `age` list in the relevant `key_groups` entry:
+
+   ```yaml
+   creation_rules:
+     - path_regex: \.enc\.yaml$
+       key_groups:
+         - age:
+             # CI Key
+             - age198gq0jfpeju4hceg3cez9mqpufe9h08upx95e2f70cr3dklttqts35ch5t
+             # Existing person's key
+             - age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
+             # New person's key
+             - age1<new-key-here>
+   ```
+
+2. Re-encrypt all secrets files:
+
+   ```sh
+   sops updatekeys .environments/staging.secrets.enc.yaml
+   ```
+
+3. Commit the updated `.sops.yaml` and re-encrypted files.
+
+## Removing access
+
+1. Remove the person's public key from `.sops.yaml`.
+2. Re-encrypt all secrets files:
+   ```sh
+   sops updatekeys .environments/staging.secrets.enc.yaml
+   ```
+3. Commit the changes.
+4. Rotate any secrets they had access to, as re-encrypting does not invalidate what was previously decrypted.

--- a/.environments/README.md
+++ b/.environments/README.md
@@ -81,10 +81,10 @@ age-keygen -o "$env:AppData\sops\age\keys.txt"
              - age1<new-key-here>
    ```
 
-2. Re-encrypt all secrets files:
+2. Re-encrypt all secrets files (run this command from within the .environments folder):
 
    ```sh
-   sops updatekeys .environments/staging.secrets.enc.yaml
+   sops updatekeys staging.secrets.enc.yaml
    ```
 
 3. Commit the updated `.sops.yaml` and re-encrypted files.

--- a/.environments/prod.secrets.enc.yaml
+++ b/.environments/prod.secrets.enc.yaml
@@ -1,0 +1,43 @@
+BEHIIV_TOKEN: ENC[AES256_GCM,data:dXIty4kkkJgMqn6oRvO7x0KOV0u/YUAG2kuo1Al4UjP0/+wnfpprLO+1sdwFm6FSZqAIZDvsoUyYypkxfAz7CA==,iv:5NqgYxeeYbRXRg5lwdM/LZ5WQpd1mt0CtXcZxHdVsYU=,tag:30EqYiflXCsCrdIKDlk2ZQ==,type:str]
+BEHIIV_PUB_KEY: ENC[AES256_GCM,data:XovyCeq9FqOoOdAZcUdykE1CsFejjK2T7ROuGcTcTqRR/bUqvQQVaw==,iv:+I+NwMRn3tKggxAyvNTndKheOHElATdp9ogCWd2gjGw=,tag:lrDYNJtjuA4v7BG5Ql6kaw==,type:str]
+RESEND_API_KEY: ENC[AES256_GCM,data:5St/a6V9hJZPa0urQ6BxacR9pQmVnmwGpXIW6o2/V8WSM4qA,iv:OW7JeQXNlaOqIc9opG0Ijrvf9xtXxyntcD0y+a52SRk=,tag:UhjMIeGxSJdNbpGvsJdTyw==,type:str]
+CONTACT_TO_EMAIL: ENC[AES256_GCM,data:bex5kV2k/0zgUTbXaYBBo2RDnMxYXwc=,iv:JRyBhbYJv19ihbDI+zG6ojwvZQPQit2fmZ6NMOoxWzw=,tag:w96HNBxP9vSCX6vhepyhYg==,type:str]
+CONTACT_FROM_EMAIL: ENC[AES256_GCM,data:wVENgndfGOMhtEkBoljYXxNoruuU73TcVw==,iv:Jkp30M2Sq7McpSz0dALxX/oHnvXoymvJXnPWlUVRDWM=,tag:ocBdDQyxTZNYdjmdxZB+Ow==,type:str]
+IBAN: ENC[AES256_GCM,data:hbamaFKQYZJTCKvePpLI+23ntQ==,iv:P1aMpv+nIjoR9/SaN5/t5cbcRB/phD4PcdeO04d9ZAk=,tag:W+TsYubZKqYJ9NJTz/c8yA==,type:str]
+BIC: ENC[AES256_GCM,data:ugvvjqVNmmSpVnw=,iv:EZ2t48xah5kX2dJo3aDJiEQe8W3dPH3OBZctHQR4GE8=,tag:399AFfiIckPwOs1srYH0cg==,type:str]
+STRAPI_URL: ENC[AES256_GCM,data:zcfAixfpoSuQyPq45brdTKHNkUgtCN4mD0ZO5C8=,iv:WVsZKUUr3LQjf0SwYK7ukDQzcZS+/R6X5pszDZRZUE4=,tag:eKp+lCGLkam2ar2NGfetHg==,type:str]
+STRAPI_DOMAIN: ENC[AES256_GCM,data:WFcC6NGqb3gtYDwQ8VQwfcwuFO9K,iv:zuYKyqUvitLoaHo6k7AzaBVN7RNw+VHuvvz+DdNQx+U=,tag:QrvjrcMlV9RrSDCRiAO+dw==,type:str]
+STRAPI_KEY: ENC[AES256_GCM,data:jtkWbDeu0Bs130rZnd2XmjhSjEuKqXSFCcyjy8yVKSKnWHS6SaWGBQg0Wwef4t4uZEDr7rcr3my0PT51x77kiyIfIteXhUH8OArjTFSRPTI+ldMsWPtZMHVZjAEvnR36MsNP65CenfU4pLY+LuAD2PuwkYiUJDdHvhF5iKFFvEJvDEURr7F1mTWHp4gu+tbWg/qPvQguXqOUu+r7AphEkDRcCKQRdsLIJRa0/wMyeosBnpkXfX9kx2txpwS7HCxyUl/iS8fyDfeIi4L9VECOEfAEh8iOGm1vdSIprtZObZ9yx4UPAVnt07Jq67zaD2lobDj1KdhPKqNyTbSCl3zEFQ==,iv:ZL/B68BiyKBaaPIKMQrexONL3ZnM8E+FL9GaNG9IHhU=,tag:/RCosqZ7nXI+5FTB3cLiwg==,type:str]
+sops:
+    age:
+        - recipient: age18czeejgx4sqes9lulh02af08z39u98lsm7dcuprk2y5yag43uegskuuhff
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVN0RWc0w2NFh2WkZaR1I0
+            MDFXU2s4ZnRoZitkTWNJVzVOb3FaQ1BKb0FZCmU2aWFpcmV3VHIwN2tiQ2VzMFBK
+            NCswV0Zrc1dlWHZ0UkwzZVIzdC9mb3MKLS0tIFhnOWRGRlBPNUJ0akFuSHd0MVBv
+            am9QWmRIblRyaURuT0JYT1VPalNRSE0KmmXQgR/kXGfHTe1WWzpYvW4+QUgJLMl5
+            EUy5QlAQB+rSwNdiXCYtyzUzh7RfYKuHx7f6yyBH9US9D3JjaBUDfQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwVnlab291dEVTSWtsM2xk
+            bHJYOENKckxTK2MrcmlUT1ZFcXh0WFNteW1rClMzYXI4K21kMnZLb3czdjhwaW1O
+            d3Zka2lScW45amk3S0h4VTRUcXdINlEKLS0tIFF3U2NFaVM3ZDdKR2hYdFEyOUh2
+            QWVPd3VHeHVKbW1aZy9qdjdzQWUzSjgKkMBS0b7B5YPzF+UIVoRfDhXSSLNrv651
+            owDAIR64oZKkz+7D+EKpv4G5L8ceE5puEc0l38uzZDGgG98GdUbn/w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByd3FKdmx4SVUycDF5QWNX
+            aTBIbHhMU3ppMXkrUy9EM2VRUjdiN3BCdEdnCjF3N3JxSUJNTDY4NTdxRnkzNHpF
+            Y25Zc2lzU25vTm52MVFIZllsYWdsUFkKLS0tIFlqeldxTkljRDBvOVBhVnBMZC9w
+            dVBKM0JUVWN2c2Q5ME5rQ0pOREJXYU0KKjxODT6f75g28OdWgtCRB4/+Q/zO+G0Y
+            k16vKGPyA8nHfjtuVLLCiXWA2tJ0U/za1rl3/BJM93pM5rgrhQhyhg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-12T18:00:47Z"
+    mac: ENC[AES256_GCM,data:aRqxsXKqSdkJKX/Rs5i73M0jAHoNkrgmcc5eCiYDkyxwpG7mjh1/ThEoCsVCdSJyoxco+6JLSr0ILMbiq2CXrS/fJNuo55ZRvW8Hr6TSQdlYG4/PtTrIH5kRMR+zQPj3PpQq5lALU4/l52LEfJyuyi5In/OYqf969rpyv0F6aEU=,iv:Q26V/6BdRSNFFRlOXJvvEeT7qd2K9nxzkltzpojKi7M=,tag:8aj8uZhKT8qZqD5y0QHqFw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1

--- a/.environments/staging.secrets.enc.yaml
+++ b/.environments/staging.secrets.enc.yaml
@@ -1,0 +1,42 @@
+BEHIIV_TOKEN: ENC[AES256_GCM,data:3y71CF2msuMMjE9IQTl1rurANkX+3bqaXyzM7pFwGS/zGULzUkczfiGXwtqILgChNtbaVcd7LoK4BTwOiNHPow==,iv:EOsKccpw2O8LMyCotlsmK9Zna9A6tKOoEJe3Lk35pXQ=,tag:LDKCBb4K8OvX1jP5YFm6kw==,type:str]
+BEHIIV_PUB_KEY: ENC[AES256_GCM,data:HVr2P82++xI/PNdYkM336wkhL0QZHuTDnON0Vie6sgLI3bQ5K4vyug==,iv:rfBR2Ypr/WCwZZRhFz10Cr17j6c/OY4CXD3NnlF5TnQ=,tag:myRg0eM11euY+htnYw3QoA==,type:str]
+RESEND_API_KEY: ENC[AES256_GCM,data:S0Wqj91aFP5H/AKiH9EPDT+MI3uy594tVigVkXzAXIMmbOuJ,iv:aVGDr029kxBS9O2JVM4QR/eGZCvv9Ejj9r3twGF+Qp4=,tag:GVvYRs5qHYgNV5r6fm44iA==,type:str]
+CONTACT_TO_EMAIL: ENC[AES256_GCM,data:YVcHZIitCViKJOR9LMqarlvSIZvf4w==,iv:PvQTcCLUG559VC8/siPK+O3UUy/WB3fe/tUF/PyWd9s=,tag:pmZBJLd6h6z0FqroJbeKOQ==,type:str]
+IBAN: ENC[AES256_GCM,data:tIiIF4xq1XOonMrVWBSV2ySYxg==,iv:Uj5ORuijeXGb9bVPyJNhOpZRVOlLDQq4WCAdR4xplug=,tag:A7SYi84d68YXzNcomC3meg==,type:str]
+BIC: ENC[AES256_GCM,data:zNOYrPZTLLws9PA=,iv:u6gA1oW7pdXUQ0ctsmTXbXrgpu1L1wueIepPea3qoog=,tag:Mp2mOJQwqSFw+eoi8PyvAQ==,type:str]
+STRAPI_URL: ENC[AES256_GCM,data:EsMP5nsIX4mAuBKWjEW/opcxaWKAMpuIKpvJtKE12Gkl3gmc3A==,iv:WW/A6h7ZYb4TDol4+91vNo1TtI/CKBeANcvQnPBz73A=,tag:Ig3YqVccq8/2d8nmKgyeiA==,type:str]
+STRAPI_DOMAIN: ENC[AES256_GCM,data:pI0ripugR+C33knbYZcDbZnAo+1tG6dFxTuO+fg=,iv:jTgBMb5aMNbapyTb/TzgIOnqfmmu0BfRFtin+oVdT8E=,tag:ODUDG0TitOqc/aSbu4UQhA==,type:str]
+STRAPI_KEY: ENC[AES256_GCM,data:8//fe0PQ4tcBbJY0eAK6IrXzP8V1tqoWTAU06xNxJx1RfHHH2Bgda6brbYvpOMka3l7Q+fLpMBOywGz+copJya9eMcQsx9u8ZfOZof17FH7hLxbh/oWsHLsN7IGtpYuZcz10g16vzx79+VzD2gcr4EGsyjuArl6/3a5KOHigW6E8NC3EDJF7z89Me81AReodk1LnJ6QYNM1zwJOoMZECZjGf/LgeR0DYMDCDEXMqBnydJJ03obd3985NpKLgSHkyh4ZVf9yfQeWcL+bon2RDTQFqzBvqtHunRx7woAmP8WeudiLj1+evVAgdQ5kWdmitslHxs4VVBBRDdqn1iN/70g==,iv:14IKFzA+ndkbrvigPV8JzbP8U94ZuHhfk/dTfTYdZqw=,tag:Yg285mWsIbaiDBp7i7Lpcg==,type:str]
+sops:
+    age:
+        - recipient: age18czeejgx4sqes9lulh02af08z39u98lsm7dcuprk2y5yag43uegskuuhff
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Zk5PMkRPdWRIZTZzTEx4
+            QXUyWW5ocWVMMno5SEtJY1M1Tys3STB2WEJVCm8rbHpKRG1adzZJWEpBWXRxc2pv
+            MVZncXJNM0JwSkJMUVJzcUZkcTA5VjgKLS0tIHY2UWtUcEFaTzlTNlpUaHJ1cHJP
+            MlBQS21JTlREb3IwcnFHdVBmZ1pENU0Kpq8EZJrIBgXyUTFri9b3KdYWCmTuDXyT
+            Gx+HJ87Lg6njsq7tADhzeikXhA93YNppX+ejQ3ebRPistMMm6PJo8g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNmM5UmdPWTAvSzlQNDdr
+            WHMzeGwrcGdwNEVlYThleHRNVllmV1oycmhnCi9jU001UUlETU9sVE92cXhNMW1W
+            bElIckw3ZXlFQzdrcTNYMDJaTlhZZm8KLS0tIEQzMXY0cWMzbjJZekV2QWtUZE04
+            SXZlRmJpZ3psQ21LMEloQW1xdmZVYmcK+BuSCxjXoUjnpZMGlQ2caUnGmE+kXpIW
+            PK8fGJdsfx5JxLDdeunEacfLTeYb0oVgNaNo7GpGDx6/Zkn6wTPmnQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIbkZzTWRmZWR0MlpXRWI1
+            OGhZS3lZbUxDOCs3SFhYSFpYemdNUTh2WEI4CnFTbGxUOWRuRlBldnNka3ROQzV1
+            ay9VcUVhK0lFbi9rOFJVVnJDL3ZHcU0KLS0tIGJvdi9ZNk1xNGVPeFpZWm5DVER3
+            ZE9jUDk3WkxQNTNTMmZDSTRJTlZ4ZFkKMhjusjolwLVR5B+r3sUFRWz9+U1kv2An
+            a26+9YL68klIDXjth+8Mlkk1AmfpPAy/7WCiKN2x3Xx+0VlG+8rE4A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-12T17:27:52Z"
+    mac: ENC[AES256_GCM,data:sO7hWjBqMwHRsnJ5ROyVnMKljlRr7it+rz+ki0XryF0fBHeEeyZRi1dT+XPqwz8Nbbl9ij19zYkv6JJestvfjdKGuYBjtGvL9GnkjjeRnC3VTqdnZN44+zz+rNJfyumqaxbAO9c3MtQbP9sGcRBhaQSqGndvNYkkp/FTNoctauU=,iv:yCDeo+BQQTm1W+Uj3kpSmKse5PisMGCzh4Gk3XV7gg0=,tag:AjPXYyu8+B/hbzWxWBfBmg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1

--- a/.environments/staging.secrets.enc.yaml
+++ b/.environments/staging.secrets.enc.yaml
@@ -12,29 +12,38 @@ sops:
         - recipient: age18czeejgx4sqes9lulh02af08z39u98lsm7dcuprk2y5yag43uegskuuhff
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Zk5PMkRPdWRIZTZzTEx4
-            QXUyWW5ocWVMMno5SEtJY1M1Tys3STB2WEJVCm8rbHpKRG1adzZJWEpBWXRxc2pv
-            MVZncXJNM0JwSkJMUVJzcUZkcTA5VjgKLS0tIHY2UWtUcEFaTzlTNlpUaHJ1cHJP
-            MlBQS21JTlREb3IwcnFHdVBmZ1pENU0Kpq8EZJrIBgXyUTFri9b3KdYWCmTuDXyT
-            Gx+HJ87Lg6njsq7tADhzeikXhA93YNppX+ejQ3ebRPistMMm6PJo8g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4eUtOWnlZNW4xZ1RGM0M5
+            RVhERkdyVzlCaVJFM3V3QnlnSDc0dHhEUkZzCldiaXYvbWtURCtHRXRSS1dPMjhO
+            MW15RmFSNE9uQ2dZalZBMVBsbTMwc2sKLS0tIFZUbmFkVFlEaWJFZnZXUzNSNEln
+            YVVZc3h4T3E3bFVyYi9TcFl3bnVYM1EKLpm9XQLovbGL5iuBVmXzDjnibJL1WyIO
+            Nkmrdg+pZabKVpLW9MKeQ6WxUmOK0UlH4GkQvTi8LJqGqm7X6uoYOw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNmM5UmdPWTAvSzlQNDdr
-            WHMzeGwrcGdwNEVlYThleHRNVllmV1oycmhnCi9jU001UUlETU9sVE92cXhNMW1W
-            bElIckw3ZXlFQzdrcTNYMDJaTlhZZm8KLS0tIEQzMXY0cWMzbjJZekV2QWtUZE04
-            SXZlRmJpZ3psQ21LMEloQW1xdmZVYmcK+BuSCxjXoUjnpZMGlQ2caUnGmE+kXpIW
-            PK8fGJdsfx5JxLDdeunEacfLTeYb0oVgNaNo7GpGDx6/Zkn6wTPmnQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjWmpnY2VDbFNrYkRaTFhN
+            dGh0WldzeEpZcWZWdkdITXBZeEhtRDhjNjNBCkxDSEJFckNKMm9Ddis2NkZhRkxX
+            Y1Q4TGx2U3pENXhIVG5FVEx2STNpaXcKLS0tIDZXYjgxSEtVY3hzYVF1NW1TQlo2
+            ODI1WDVwcTNjZGRnZWRJZkhyYVpFVkUK0XhJrELU/s6TXOCWLRI2f+hx5+sCc+aH
+            arKwolfley4909irdfhHBn4ZUhaOJnTckvCcQ0NhaOjNfxuRY0OBqA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIbkZzTWRmZWR0MlpXRWI1
-            OGhZS3lZbUxDOCs3SFhYSFpYemdNUTh2WEI4CnFTbGxUOWRuRlBldnNka3ROQzV1
-            ay9VcUVhK0lFbi9rOFJVVnJDL3ZHcU0KLS0tIGJvdi9ZNk1xNGVPeFpZWm5DVER3
-            ZE9jUDk3WkxQNTNTMmZDSTRJTlZ4ZFkKMhjusjolwLVR5B+r3sUFRWz9+U1kv2An
-            a26+9YL68klIDXjth+8Mlkk1AmfpPAy/7WCiKN2x3Xx+0VlG+8rE4A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEaUVMdkRUMXUydkFOcGZq
+            WERiaklqL2RrVFVvSCtSbjJacjl5UlRWWUJjCnF3ZXJGRUlUYlZ3aS9IUERITkgr
+            Q2VjMkZYWlNGYncyY0pLZUlCMWp3YlkKLS0tIFYxTXptWFRPeWlESHVzZXpBSUc2
+            eWpjOTVHM3BQa3MxdEZLbVR0STJ6WHMKXssJtpegjT7eX8mFyO05kLY3HAtrlfzH
+            8lSd455AT/f567+F+pxpf2q9wG9G/O33igfC/Yt3HfFDCftmACqvCA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1zzr7w9eefkgevmv4k4s0uncl5lkff48gjde4rmt0pqr8z278r9zspqrx3q
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyR1huL3VqNlptNVZMVEtj
+            am5MTk0wM1lQaG02T3ZWbWJjcXd0SGRWdFhzCmIwblcraTZ4YU93QVFrVEZ4R0c4
+            bzZXTkRkRE45VU5YS3pDVjB2ZUJkeEUKLS0tIG55Y05lUmJyWm9aU1UrZlo5TDQy
+            S01xd3VzMC9mQzVaQ1VSN2crNkVMSmsKf0TTIBGGwCdDE6YgLq8VtNl5Z+oSs3nH
+            uUiQsXENmUcp+uRJdff6KBaUubxfbr1VsI4Open4UE3sNRZLsG7jLg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-04-12T17:27:52Z"
     mac: ENC[AES256_GCM,data:sO7hWjBqMwHRsnJ5ROyVnMKljlRr7it+rz+ki0XryF0fBHeEeyZRi1dT+XPqwz8Nbbl9ij19zYkv6JJestvfjdKGuYBjtGvL9GnkjjeRnC3VTqdnZN44+zz+rNJfyumqaxbAO9c3MtQbP9sGcRBhaQSqGndvNYkkp/FTNoctauU=,iv:yCDeo+BQQTm1W+Uj3kpSmKse5PisMGCzh4Gk3XV7gg0=,tag:AjPXYyu8+B/hbzWxWBfBmg==,type:str]

--- a/.environments/staging.secrets.enc.yaml
+++ b/.environments/staging.secrets.enc.yaml
@@ -12,38 +12,38 @@ sops:
         - recipient: age18czeejgx4sqes9lulh02af08z39u98lsm7dcuprk2y5yag43uegskuuhff
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4eUtOWnlZNW4xZ1RGM0M5
-            RVhERkdyVzlCaVJFM3V3QnlnSDc0dHhEUkZzCldiaXYvbWtURCtHRXRSS1dPMjhO
-            MW15RmFSNE9uQ2dZalZBMVBsbTMwc2sKLS0tIFZUbmFkVFlEaWJFZnZXUzNSNEln
-            YVVZc3h4T3E3bFVyYi9TcFl3bnVYM1EKLpm9XQLovbGL5iuBVmXzDjnibJL1WyIO
-            Nkmrdg+pZabKVpLW9MKeQ6WxUmOK0UlH4GkQvTi8LJqGqm7X6uoYOw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOOThwZEZsTndxVEhPWlNt
+            SUp3MmphK2FsKy8zM3ExVlAyY1JzNTNlUFdvCjJzcklvbWhlZ2RHOUlkWU9vSUsv
+            bENkZUswOGQ1TTQwWExFUDE2YnZBK1kKLS0tIE1LMU9RaXUvZFdvUE9GUU5qT0pn
+            L01ueHoyZkYwOXhCaVdlU0tKUzg1SnMK8S/dUwvDo0jI1Idt+FWl6JYBwDgrXueI
+            XAnmlRlnGSUG5mom9P+LyNwpJzG8FJf5tDzHmOXArtsQHzyVIuxU1A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age16z3ewnx22h4j4qxmaj43yysag8a3gnxs46mm9p0s92lcykwr952syq8365
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjWmpnY2VDbFNrYkRaTFhN
-            dGh0WldzeEpZcWZWdkdITXBZeEhtRDhjNjNBCkxDSEJFckNKMm9Ddis2NkZhRkxX
-            Y1Q4TGx2U3pENXhIVG5FVEx2STNpaXcKLS0tIDZXYjgxSEtVY3hzYVF1NW1TQlo2
-            ODI1WDVwcTNjZGRnZWRJZkhyYVpFVkUK0XhJrELU/s6TXOCWLRI2f+hx5+sCc+aH
-            arKwolfley4909irdfhHBn4ZUhaOJnTckvCcQ0NhaOjNfxuRY0OBqA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXSTNSS3oycS9aL2dJaGJ3
+            Rmxtb200WmhveHc3ZlZYZGJRZ0xJMWMvT2p3CklhUUg4T3R2WjB5U3F6dEVJZVVM
+            UEpQMC9SSmhqQ0pLcmxJaWZHUmtyMGsKLS0tIGdManBWZU1sOCs2RW5zN1QzK3Ni
+            U0lBZGRsdzg5QWQyZmhuS2RKQ1ZuSk0KZignKGlF5W0XaN/PJJU8G5dWBgmYYX1+
+            SwaH7gZWOeDU9RDag9Pol9avUAeR3N42cpWSWxFE9jJP9zdjiUkp/g==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1k349xhtvfswn44wprj03pnlxafry0y2uyl23hy3e8zpxavjaysmqg62q9y
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEaUVMdkRUMXUydkFOcGZq
-            WERiaklqL2RrVFVvSCtSbjJacjl5UlRWWUJjCnF3ZXJGRUlUYlZ3aS9IUERITkgr
-            Q2VjMkZYWlNGYncyY0pLZUlCMWp3YlkKLS0tIFYxTXptWFRPeWlESHVzZXpBSUc2
-            eWpjOTVHM3BQa3MxdEZLbVR0STJ6WHMKXssJtpegjT7eX8mFyO05kLY3HAtrlfzH
-            8lSd455AT/f567+F+pxpf2q9wG9G/O33igfC/Yt3HfFDCftmACqvCA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0WG9ocjVINEVUcmpDbSt5
+            VS95Y0QxMGNHRG9xYzkyU1ZEc21jSXJzUVg0Ck12SE1aUENoeFQwRHFLUFE3THNQ
+            V0pDMlZENVo2bHZkRi8xcDBaSWpHS0UKLS0tIHQ0cWpDcXluZDhPTTNEOFpXeGZo
+            M2o2cDJSQUxFM2tQZzNmUTJLRDJoSjQKlhXeamNYqYN++yDMKWaF7IfnGozL6cIy
+            dEvEoGYs8fUWA5p988aaVGIi4VnLdqtFAWoGAE+pLPU1+37JKEWOlQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1zzr7w9eefkgevmv4k4s0uncl5lkff48gjde4rmt0pqr8z278r9zspqrx3q
+        - recipient: age1mzmws9mpksrk7chzxwrg570x77gjdsspswpzuta9q38fy7a57f5q0ks5x4
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyR1huL3VqNlptNVZMVEtj
-            am5MTk0wM1lQaG02T3ZWbWJjcXd0SGRWdFhzCmIwblcraTZ4YU93QVFrVEZ4R0c4
-            bzZXTkRkRE45VU5YS3pDVjB2ZUJkeEUKLS0tIG55Y05lUmJyWm9aU1UrZlo5TDQy
-            S01xd3VzMC9mQzVaQ1VSN2crNkVMSmsKf0TTIBGGwCdDE6YgLq8VtNl5Z+oSs3nH
-            uUiQsXENmUcp+uRJdff6KBaUubxfbr1VsI4Open4UE3sNRZLsG7jLg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxQkJ4d2sxOG85V0dWMU10
+            TkY3Q0FNL3NaZzlzSU9NRmZsNVZLVG1xanpjCmNpWTBtMU1MYmRob3kyeEd4dVhC
+            WDJ0SzFVajZVbGwwbTNrZ0EyTHlVSVUKLS0tIHlEL1h0RVpCYmVpbzFZMTdiU1M5
+            Vm50R3pxMyt1amZJNDVyMHp0cHZicWsKpeVz1+t2Vytvw0UZqAMdXv+XG6BXF4CT
+            B4nI7YKS/psyxFxFhEL3W8srjNC575npY+s6coCUkul4UpXDhbTiIA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-04-12T17:27:52Z"
     mac: ENC[AES256_GCM,data:sO7hWjBqMwHRsnJ5ROyVnMKljlRr7it+rz+ki0XryF0fBHeEeyZRi1dT+XPqwz8Nbbl9ij19zYkv6JJestvfjdKGuYBjtGvL9GnkjjeRnC3VTqdnZN44+zz+rNJfyumqaxbAO9c3MtQbP9sGcRBhaQSqGndvNYkkp/FTNoctauU=,iv:yCDeo+BQQTm1W+Uj3kpSmKse5PisMGCzh4Gk3XV7gg0=,tag:AjPXYyu8+B/hbzWxWBfBmg==,type:str]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,5 +28,5 @@ jobs:
           repo_name: next-website-v2
           infra_checkout_token: ${{ secrets.INFRA_CHECKOUT_TOKEN }}
           upcloud_token: ${{ secrets.UPCLOUD_TOKEN }}
-          ansible_ssh_private_key: ${{ (inputs.environment || 'staging') == 'staging' && secrets.ANSIBLE_API_STAGING_SSH_PRIVATE_KEY || secrets.ANSIBLE_API_PROD_SSH_PRIVATE_KEY }}
+          ansible_ssh_private_key: ${{ (inputs.environment || 'staging') == 'staging' && secrets.ANSIBLE_NEXT_WEBSITE_STAGING_SSH_PRIVATE_KEY || secrets.ANSIBLE_NEXT_WEBSITE_PROD_SSH_PRIVATE_KEY }}
           sops_age_key: ${{ (inputs.environment || 'staging') == 'staging' && secrets.SOPS_STAGING_AGE_KEY || secrets.SOPS_PROD_AGE_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+      branch:
+        description: "Branch to deploy"
+        required: true
+        default: main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'staging' }}
+    steps:
+      - name: Deploy application
+        uses: distributeaid/centralised-github-actions/.github/actions/ansible-deploy@main
+        with:
+          environment: ${{ inputs.environment || 'staging' }}
+          branch: ${{ inputs.branch || github.ref_name }}
+          repo_name: next-website-v2
+          infra_checkout_token: ${{ secrets.INFRA_CHECKOUT_TOKEN }}
+          upcloud_token: ${{ secrets.UPCLOUD_TOKEN }}
+          ansible_ssh_private_key: ${{ (inputs.environment || 'staging') == 'staging' && secrets.ANSIBLE_API_STAGING_SSH_PRIVATE_KEY || secrets.ANSIBLE_API_PROD_SSH_PRIVATE_KEY }}
+          sops_age_key: ${{ (inputs.environment || 'staging') == 'staging' && secrets.SOPS_STAGING_AGE_KEY || secrets.SOPS_PROD_AGE_KEY }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .yarn/
 next-env.d.ts
+.environment/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 .yarn/
 next-env.d.ts
-.environment/*
+.environments/*

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  apps: [
+    {
+      name: "next-website-v2",
+      cwd: "/home/deploy/next-website-v2",
+      script: "yarn",
+      args: "start",
+      interpreter: "none",
+      env_file: ".env",
+      env: {
+        NODE_ENV: "production",
+        NODE_OPTIONS: "--max-old-space-size=2048",
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## What changed?
Adding the deploy workflows as well as the SOPS files for Github Actions deployment.
This needs to be merged to start testing the deployment, as the action is meant to be triggered manually and the workflow_dispatch handler only appears when the workflow exists in Main.
Fixes #1082
<!-- include a link to a GitHub issue, if applicable -->

## How will this change be visible?

<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)