### PR TITLE
fix/1080/how aid is delivered

### DIFF
--- a/src/components/home/HowWeHelp.tsx
+++ b/src/components/home/HowWeHelp.tsx
@@ -188,27 +188,32 @@ const HowWeHelp = () => {
           />
         </Flex>
         {/* Grid Section */}
-        <Flex justify="center" width="100%">
-          <Grid
-            columns={{
-              initial: "1",
-              md: "2",
-              lg: "3",
-            }}
-            width="100%"
-            gap={{ initial: "5", md: "7", lg: "8" }}
-            asChild
-          >
-            <ul aria-label="How We Help Columns">
-              {items.map((column, idx) => (
-                <li key={idx} aria-label={`How We Help Column ${idx + 1}`}>
-                  <Flex justify="center" width="100%">
-                    <GridColumn column={column} columnIndex={idx} />
-                  </Flex>
-                </li>
-              ))}
-            </ul>
-          </Grid>
+
+        <Flex
+          columns={{
+            initial: "1",
+            md: "2",
+            lg: "3",
+          }}
+          width={{
+            initial: "200px",
+            md: "100%",
+          }}
+          gap={{ initial: "5", md: "7", lg: "8" }}
+          direction={{
+            initial: "column",
+            md: "row",
+          }}
+          className="justify-around mx-auto"
+          asChild
+        >
+          <ul aria-label="How We Help Columns">
+            {items.map((column, idx) => (
+              <li key={idx} aria-label={`How We Help Column ${idx + 1}`}>
+                <GridColumn column={column} columnIndex={idx} />
+              </li>
+            ))}
+          </ul>
         </Flex>
       </Section>
     </Box>

--- a/src/components/home/HowWeHelp.tsx
+++ b/src/components/home/HowWeHelp.tsx
@@ -190,11 +190,6 @@ const HowWeHelp = () => {
         {/* Grid Section */}
 
         <Flex
-          columns={{
-            initial: "1",
-            md: "2",
-            lg: "3",
-          }}
           width={{
             initial: "200px",
             md: "100%",


### PR DESCRIPTION
Fixes #1080

## What changed?

Closes #1080

Cleaned up HowWeHelp component, fixed alignment for mobile view

## How will this change be visible?

Items will now be aligned on mobile.

<img width="872" height="1106" alt="image" src="https://github.com/user-attachments/assets/e5d954e1-93bb-4e04-b1fc-bd0676f7928c" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)