### PR TITLE
feat/1093/implemented responses submenu on navbar and reponses links …

### DIFF
--- a/src/components/nav/navBar.tsx
+++ b/src/components/nav/navBar.tsx
@@ -105,6 +105,7 @@ const NavBar = () => {
                   })}
                   key={title}
                 >
+                  {/* SubMenu */}
                   {isSubMenu ? (
                     <Box className="group">
                       <Flex position={"relative"} align={"center"} asChild>
@@ -118,7 +119,7 @@ const NavBar = () => {
                       <Flex
                         asChild
                         position={"absolute"}
-                        maxWidth={"140px"}
+                        maxWidth={"160px"}
                         mt={"3"}
                         className="shadow-md bg-white z-10 border rounded-md"
                       >

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -359,19 +359,19 @@ export const FOOTER_COLUMNS: FooterColumn[] = [
         link: "/resources/assort",
       },
       {
-        name: "US Disaster Preparedness",
+        name: Messages.US_DISASTER_PREPAREDNESS_RESPONSE_PAGE_TITLE,
         link: "/responses/us-disaster-preparedness",
       },
       {
-        name: "Levant Response",
+        name: Messages.LEVANT_RESPONSE_PAGE_TITLE,
         link: "/responses/levant",
       },
       {
-        name: "Refugee Support Europe",
+        name: Messages.REFUGEE_SUPPORT_EUROPE_RESPONSE_PAGE_TITLE,
         link: "/responses/refugee-support-eu",
       },
       {
-        name: "HRT Harm Reduction Toolkit",
+        name: Messages.HRT_TOOLKIT_RESPONSE_PAGE_TITLE,
         link: "/responses/hrt-toolkit",
       },
     ],

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -359,6 +359,18 @@ export const FOOTER_COLUMNS: FooterColumn[] = [
         link: "/resources/assort",
       },
       {
+        name: "US Disaster Preparedness",
+        link: "/responses/us-disaster-preparedness",
+      },
+      {
+        name: "Levant Response",
+        link: "/responses/levant",
+      },
+      {
+        name: "Refugee Support Europe",
+        link: "/responses/refugee-support-eu",
+      },
+      {
         name: "HRT Harm Reduction Toolkit",
         link: "/responses/hrt-toolkit",
       },

--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -18,3 +18,5 @@ export const TEAM_PAGE_TITLE = "Team";
 export const TECH_PAGE_TITLE = "Tech";
 
 export const DONATE_PAGE_TITLE = "Donate";
+
+export const RESPONSES_PAGE_TITLE = "Responses";

--- a/src/data/messages.ts
+++ b/src/data/messages.ts
@@ -20,3 +20,13 @@ export const TECH_PAGE_TITLE = "Tech";
 export const DONATE_PAGE_TITLE = "Donate";
 
 export const RESPONSES_PAGE_TITLE = "Responses";
+
+export const US_DISASTER_PREPAREDNESS_RESPONSE_PAGE_TITLE =
+  "US Disaster Preparedness";
+
+export const LEVANT_RESPONSE_PAGE_TITLE = "Levant Response";
+
+export const REFUGEE_SUPPORT_EUROPE_RESPONSE_PAGE_TITLE =
+  "Refugee Support Europe";
+
+export const HRT_TOOLKIT_RESPONSE_PAGE_TITLE = "HRT Harm Reduction Toolkit";

--- a/src/data/navBarLinks.ts
+++ b/src/data/navBarLinks.ts
@@ -25,6 +25,33 @@ export const links = [
       },
     ],
   },
+  {
+    title: Messages.RESPONSES_PAGE_TITLE,
+    url: "/responses",
+    isSubMenu: true,
+    subMenu: [
+      {
+        title: Messages.OVERVIEW_NAV_ITEM_TITLE,
+        url: "/responses",
+      },
+      {
+        title: "US Disaster Preparedness",
+        url: "/responses/us-disaster-preparedness",
+      },
+      {
+        title: "Levant Response",
+        url: "/responses/levant",
+      },
+      {
+        title: "Refugee Support Europe",
+        url: "/responses/refugee-support-eu",
+      },
+      {
+        title: "HRT Harm Reduction Toolkit",
+        url: "/responses/hrt-toolkit",
+      },
+    ],
+  },
   // {
   //   id: 3,
   //   title: "Needs",

--- a/src/data/navBarLinks.ts
+++ b/src/data/navBarLinks.ts
@@ -35,19 +35,19 @@ export const links = [
         url: "/responses",
       },
       {
-        title: "US Disaster Preparedness",
+        title: Messages.US_DISASTER_PREPAREDNESS_RESPONSE_PAGE_TITLE,
         url: "/responses/us-disaster-preparedness",
       },
       {
-        title: "Levant Response",
+        title: Messages.LEVANT_RESPONSE_PAGE_TITLE,
         url: "/responses/levant",
       },
       {
-        title: "Refugee Support Europe",
+        title: Messages.REFUGEE_SUPPORT_EUROPE_RESPONSE_PAGE_TITLE,
         url: "/responses/refugee-support-eu",
       },
       {
-        title: "HRT Harm Reduction Toolkit",
+        title: Messages.HRT_TOOLKIT_RESPONSE_PAGE_TITLE,
         url: "/responses/hrt-toolkit",
       },
     ],


### PR DESCRIPTION
…in footer

## What changed?
- Added responses submenu on navbar 
- Added reponses links in footer
- increased submenu maxwidth from 140px to 160px so that response names fit on max two lines
Fixes #1093
<!-- include a link to a GitHub issue, if applicable -->
#1093 
## How will this change be visible?
visibible on navbar and footer
<!-- pages, components, etc. -->

## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (describe)

Note: Some of these response pages and the response overview page are not implemented yet