### PR TITLE
content/1128/image attribution

### DIFF
--- a/src/app/responses/levant/page.tsx
+++ b/src/app/responses/levant/page.tsx
@@ -45,10 +45,18 @@ const HrtToolkit: FC = () => {
           {
             img: "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/gaza_emergency-response_2024-february-20_IMG-20240220-WA0019-EDIT_vstfeb.jpg",
             alt: "The first about image",
+            attribution: {
+              name: "Anera",
+              href: "https://anera.org/",
+            },
           },
           {
             img: "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/GazaAnera2024_fyn9zs.jpg",
             alt: "The second about image",
+            attribution: {
+              name: "Anera",
+              href: "https://anera.org/",
+            },
           },
         ]}
         ctaText="Send Aid to the Levant"
@@ -67,6 +75,10 @@ const HrtToolkit: FC = () => {
             title: "Give money",
             image:
               "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/IMG-20240120-WA0010_1_ktrfxi.jpg",
+            imageAttribution: {
+              name: "Anera",
+              href: "https://anera.org/",
+            },
             buttonText: "Send Aid to the Levant",
             link: "https://www.omprakash.org/global/distribute-aid/crowdfund/send-aid-to-the-levant",
             children: (
@@ -81,6 +93,10 @@ const HrtToolkit: FC = () => {
             title: "Donate supplies",
             image:
               "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/gaza_emergency-response_2024-february-18_IMG-20240218-WA0006-EDIT_1_pr2ap8.jpg",
+            imageAttribution: {
+              name: "Anera",
+              href: "https://anera.org/",
+            },
             buttonText: "Reach out to donate in kind",
             link: "mailto:donate-aid@distributeaid.org",
             children: (

--- a/src/app/responses/levant/page.tsx
+++ b/src/app/responses/levant/page.tsx
@@ -1,12 +1,13 @@
 import { FC } from "react";
 import { Link } from "@radix-ui/themes";
 import { ResponseHero } from "@/components/responses/ResponseHero";
+import { AboutTheProject } from "@/components/responses/AboutTheProject";
 import { LevantByTheNumbers } from "@/components/responses/levant/LevantByTheNumbers";
 import { HowWeWork } from "@/components/responses/HowWeWork";
 import { GetInvolved } from "@/components/responses/GetInvolved";
 import { Faq } from "@/components/responses/Faq";
 
-import { faqs } from "@/data/hrtToolkitData";
+import { faqs } from "@/data/levantResponseData";
 
 import graphHorizontal from "../../../../public/images/illus/levant-response/illus-how-it-works-graph.png";
 import graphVertical from "../../../../public/images/illus/levant-response/illus-how-it-works-vertical.png";
@@ -14,26 +15,46 @@ import graphVertical from "../../../../public/images/illus/levant-response/illus
 const HrtToolkit: FC = () => {
   return (
     <main>
-      <ResponseHero title="Levant Response">
-        <span className="mb-5 block">
-          We provide emergency relief to war refugees, and equip them with the
-          tools and training needed to help their own communities. We do this by
-          sourcing bulk quantities of food, medical equipment, and hygiene
-          products from donors—and asking displaced people what they need to
-          heal.
-        </span>
-
-        <span className="block">
-          Then we package those goods into shipping containers and transport
-          them to Lebanon, Jordan, and occupied Palestine. There, we work with
-          our partners at{" "}
-          <Link href="https://www.anera.org/" target="_blank">
-            Anera
-          </Link>{" "}
-          to get this life-saving aid directly into the hands of people in need.
-        </span>
-      </ResponseHero>
+      <ResponseHero title="Levant Response"></ResponseHero>
       <LevantByTheNumbers />
+      <AboutTheProject
+        heading="About The US Disaster Preparedness Project"
+        summary={
+          <>
+            <span className="mb-5 block">
+              We provide emergency relief to war refugees, and equip them with
+              the tools and training needed to help their own communities. We do
+              this by sourcing bulk quantities of food, medical equipment, and
+              hygiene products from donors—and asking displaced people what they
+              need to heal.
+            </span>
+
+            <span className="block">
+              Then we package those goods into shipping containers and transport
+              them to Lebanon, Jordan, and occupied Palestine. There, we work
+              with our partners at{" "}
+              <Link href="https://www.anera.org/" target="_blank">
+                Anera
+              </Link>{" "}
+              to get this life-saving aid directly into the hands of people in
+              need.
+            </span>
+          </>
+        }
+        images={[
+          {
+            img: "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/gaza_emergency-response_2024-february-20_IMG-20240220-WA0019-EDIT_vstfeb.jpg",
+            alt: "The first about image",
+          },
+          {
+            img: "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/GazaAnera2024_fyn9zs.jpg",
+            alt: "The second about image",
+          },
+        ]}
+        ctaText="Help Us Fund More Kits"
+        donateText="Donate via Omprakash"
+        donateURL="https://www.omprakash.org/global/distribute-aid/crowdfund/us-disaster-relief"
+      />
       <HowWeWork
         title="How We Work"
         chartHorizontal={graphHorizontal}

--- a/src/app/responses/levant/page.tsx
+++ b/src/app/responses/levant/page.tsx
@@ -51,9 +51,9 @@ const HrtToolkit: FC = () => {
             alt: "The second about image",
           },
         ]}
-        ctaText="Help Us Fund More Kits"
+        ctaText="Send Aid to the Levant"
         donateText="Donate via Omprakash"
-        donateURL="https://www.omprakash.org/global/distribute-aid/crowdfund/us-disaster-relief"
+        donateURL="https://www.omprakash.org/global/distribute-aid/crowdfund/send-aid-to-the-levant"
       />
       <HowWeWork
         title="How We Work"

--- a/src/app/responses/levant/page.tsx
+++ b/src/app/responses/levant/page.tsx
@@ -18,7 +18,7 @@ const HrtToolkit: FC = () => {
       <ResponseHero title="Levant Response"></ResponseHero>
       <LevantByTheNumbers />
       <AboutTheProject
-        heading="About The US Disaster Preparedness Project"
+        heading="About Levant Emergency Relief"
         summary={
           <>
             <span className="mb-5 block">

--- a/src/components/responses/AboutTheProject.tsx
+++ b/src/components/responses/AboutTheProject.tsx
@@ -72,7 +72,7 @@ export const AboutTheProject: FC<AboutTheProjectProps> = ({
                   width={400}
                   height={400}
                   src={img}
-                  className="w-full h-auto max-h-[400px] object-cover"
+                  className="w-full h-full object-cover"
                   alt={alt}
                 />
               </Box>

--- a/src/components/responses/AboutTheProject.tsx
+++ b/src/components/responses/AboutTheProject.tsx
@@ -11,12 +11,18 @@ import {
 import Link from "next/link";
 import Image, { StaticImageData } from "next/image";
 
+import ImageAttribution from "./ImageAttribution";
+
 interface AboutTheProjectProps {
   heading: string;
   summary: ReactNode;
   images: {
     img: StaticImageData | string;
     alt: string;
+    attribution?: {
+      name: string;
+      href: string;
+    };
   }[];
   listItems?: string[];
   ctaText: string;
@@ -60,14 +66,20 @@ export const AboutTheProject: FC<AboutTheProjectProps> = ({
         >
           <Text as="p">{summary}</Text>
           <Flex justify="between" wrap="wrap">
-            {images.map(({ img, alt }, index) => (
+            {images.map(({ img, alt, attribution }, index) => (
               <Box
                 key={index}
                 height={{ initial: "400" }}
                 width={{ sm: "100vw", md: "48%" }}
-                className="rounded-lg overflow-hidden"
+                className="rounded-lg overflow-hidden relative"
                 m="2"
               >
+                {attribution && (
+                  <ImageAttribution
+                    name={attribution.name}
+                    href={attribution.href}
+                  />
+                )}
                 <Image
                   width={400}
                   height={400}

--- a/src/components/responses/GetInvolved.tsx
+++ b/src/components/responses/GetInvolved.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode, useId } from "react";
 import { Button, Heading, Section, Text } from "@radix-ui/themes";
 import Image, { StaticImageData } from "next/image";
 import Link from "next/link";
+import ImageAttribution from "./ImageAttribution";
 
 interface GetInvolvedProps {
   boxes: GetInvolvedBoxType[];
@@ -31,6 +32,10 @@ type GetInvolvedBoxType = {
   buttonText: string;
   children?: ReactNode;
   image: StaticImageData | string;
+  imageAttribution?: {
+    name: string;
+    href: string;
+  };
   link: string;
   title: string;
 };
@@ -39,18 +44,24 @@ const GetInvolvedBox: FC<GetInvolvedBoxType> = ({
   buttonText,
   children,
   image,
+  imageAttribution: attribution,
   link,
   title,
 }) => (
   <div className="get-involved bg-navy-300 rounded-md m-4 w-full md:w-1/3">
-    <Image
-      src={image}
-      className="w-full h-auto rounded-t-md max-h-[390px]"
-      objectFit="cover"
-      width={400}
-      height={390}
-      alt={title}
-    />
+    <div className="relative">
+      {attribution && (
+        <ImageAttribution name={attribution.name} href={attribution.href} />
+      )}
+      <Image
+        src={image}
+        className="w-full h-auto rounded-t-md max-h-[390px]"
+        objectFit="cover"
+        width={400}
+        height={390}
+        alt={title}
+      />
+    </div>
     <div className="p-5">
       <div className="mb-4">
         <Text size="7" className="uppercase text-navy-800 mb-6 font-bold">

--- a/src/components/responses/ImageAttribution.tsx
+++ b/src/components/responses/ImageAttribution.tsx
@@ -1,0 +1,21 @@
+import { Text } from "@radix-ui/themes";
+import { ReactNode } from "react";
+
+interface ImageAttributionProps {
+  name: string;
+  href: string;
+}
+
+const ImageAttribution = ({ name, href }: ImageAttributionProps) => (
+  <Text
+    size="1"
+    className="absolute right-0 bottom-0 bg-gray-500/75 text-white py-1 px-3"
+  >
+    Image credit:{" "}
+    <a href={href} className="underline" target="_blank">
+      {name}
+    </a>
+  </Text>
+);
+
+export default ImageAttribution;


### PR DESCRIPTION
Fixes #1128

## What changed?

Added ImageAttribution component, and add it to images on levant response page. 

## How will this change be visible?

All images on `/responses/levant` now have image attribution.

<img width="1010" height="744" alt="image" src="https://github.com/user-attachments/assets/b7627a19-8308-48e7-b4ff-0a590432c89b" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)