### PR TITLE
fix/1118/global aid section layout

### DIFF
--- a/src/components/home/WhereWeWork.tsx
+++ b/src/components/home/WhereWeWork.tsx
@@ -35,13 +35,37 @@ const WhereWeWork = () => {
     <Section className="bg-slate-100 p-12" aria-labelledby={headingId}>
       <Box mb="9">
         <SectionHeading id={headingId}>Global Aid Network</SectionHeading>
-        <Flex gap="6" justify="center" mt="5" asChild>
+        <Flex
+          gap={{
+            initial: "3",
+            sm: "6",
+          }}
+          justify="center"
+          mt="5"
+          asChild
+        >
           <ul>
             {mapKey.map(({ label, color }) => (
               <li key={label}>
-                <Flex gap="3">
-                  <Box className={`size-8 rounded-full ${color}`} />
-                  <Text size="6">{label}</Text>
+                <Flex
+                  gap={{
+                    initial: "1",
+                    sm: "3",
+                  }}
+                  align="center"
+                >
+                  <Box
+                    className={`size-4 sm:size-6 md:size-8 rounded-full ${color}`}
+                  />
+                  <Text
+                    size={{
+                      initial: "2",
+                      sm: "4",
+                      md: "6",
+                    }}
+                  >
+                    {label}
+                  </Text>
                 </Flex>
               </li>
             ))}


### PR DESCRIPTION
Fixes #1118

## What changed?

Closes #1118 

Fixed responsive layout of the Global Aid Network section on the home page to prevent horizontal overflow.

## How will this change be visible?

Map key will now render smaller on mobile (per the [Figma Design](https://www.figma.com/design/VV226wpUPfAUsRv7gYrh1u/DA-Redesigns-2025?node-id=567-3316&p=f))

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (Check home page does not scroll horizontally on mobile)