### PR TITLE
feat/1112/nested-links-under-about-us-have-small-tap-targets-on-mobile

### DIFF
--- a/src/components/nav/mobileNavBar.tsx
+++ b/src/components/nav/mobileNavBar.tsx
@@ -47,7 +47,8 @@ const MobileNavBar = () => {
                           <Flex
                             key={title}
                             as="div"
-                            p={"1"}
+                            py="3"
+                            px="1"
                             width={"100%"}
                             style={{
                               textDecorationThickness: "2px",


### PR DESCRIPTION
Fixes #1112

## What changed?
Increase vertical spacing for nested links under "About Us" by increasing `padding-y` only. Now, each link has a `48px` tap area. Below image is for reference:

<img width="564" height="432" alt="image" src="https://github.com/user-attachments/assets/23a6e24e-65be-4e7a-be87-8ae8ebf8be79" />

## How will this change be visible?
Expand "About Us" on a mobile screen size. Observe the vertical spacing between the links have increased.

## How can you test this change?
[x] Manual tests (describe)
Open up browser dev tools, toggle device size to a smaller size, toggle the element selector, hover over the nested links under "About Us" to see new spacing dimensions.