### PR TITLE
feat/1113/newsletter-link-on-mobile-doesnt-navigate-to-correct-section-when-tapped

### DIFF
--- a/src/components/nav/mobileNavBar.tsx
+++ b/src/components/nav/mobileNavBar.tsx
@@ -6,7 +6,11 @@ import { links } from "@/data/navBarLinks";
 import { SOCIAL_LINKS } from "@/data/constants";
 import Image from "next/image";
 
-const MobileNavBar = () => {
+const MobileNavBar = ({
+  shouldShowNav,
+}: {
+  shouldShowNav: (nav: boolean) => void;
+}) => {
   return (
     <Flex
       display={{ initial: "flex", md: "none" }}
@@ -78,46 +82,53 @@ const MobileNavBar = () => {
               )}
             </Accordion.Item>
           ))}
-      </Accordion.Root>
 
-      {/* NewsLetter */}
-      <NavigationMenu.Item>
-        <NavigationMenu.Link href="#newsletter-signup">
-          Newsletter
-        </NavigationMenu.Link>
-      </NavigationMenu.Item>
-
-      {/* Social media links */}
-      <Flex justify={"center"} gapX={"2"}>
-        {SOCIAL_LINKS.slice(0, 3).map((social) => (
-          <NavigationMenu.Item key={social.name} aria-label={social.ariaLabel}>
-            <NavigationMenu.Link href={social.link} target="_blank">
-              <Image
-                src={`/images/icons/icon-social-${social.name}.svg`}
-                alt={social.name}
-                width={30}
-                height={30}
-              />
-            </NavigationMenu.Link>
-          </NavigationMenu.Item>
-        ))}
-      </Flex>
-
-      {/* Donate Button (Ensure it appears last) */}
-      <Flex
-        as="div"
-        asChild
-        width={"100%"}
-        justify={"center"}
-        p={"2"}
-        className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-normal cursor-pointer rounded-lg"
-      >
-        <NavigationMenu.Item>
-          <NavigationMenu.Link href="/donate" target="" rel="noreferrer">
-            Donate
+        {/* NewsLetter */}
+        <NavigationMenu.Item className="py-4">
+          <NavigationMenu.Link
+            href="#newsletter-signup"
+            onClick={() => shouldShowNav(false)}
+          >
+            Newsletter
           </NavigationMenu.Link>
         </NavigationMenu.Item>
-      </Flex>
+
+        {/* Social media links */}
+        <Flex gapX={"2"} py="4">
+          {SOCIAL_LINKS.slice(0, 3).map((social) => (
+            <NavigationMenu.Item
+              key={social.name}
+              aria-label={social.ariaLabel}
+            >
+              <NavigationMenu.Link href={social.link} target="_blank">
+                <Image
+                  src={`/images/icons/icon-social-${social.name}.svg`}
+                  alt={social.name}
+                  width={30}
+                  height={30}
+                />
+              </NavigationMenu.Link>
+            </NavigationMenu.Item>
+          ))}
+        </Flex>
+
+        {/* Donate Button (Ensure it appears last) */}
+        <Flex
+          as="div"
+          asChild
+          width={"100%"}
+          justify={"center"}
+          p={"2"}
+          mt={"4"}
+          className="hover:bg-navy-500 hover:text-white duration-200 text-dark-blue bg-white font-normal cursor-pointer rounded-lg"
+        >
+          <NavigationMenu.Item>
+            <NavigationMenu.Link href="/donate" target="" rel="noreferrer">
+              Donate
+            </NavigationMenu.Link>
+          </NavigationMenu.Item>
+        </Flex>
+      </Accordion.Root>
     </Flex>
   );
 };

--- a/src/components/nav/navBar.tsx
+++ b/src/components/nav/navBar.tsx
@@ -192,7 +192,7 @@ const NavBar = () => {
               </button>
             </Flex>
             {/* Mobile Menu */}
-            {nav && <MobileNavBar />}
+            {nav && <MobileNavBar shouldShowNav={setNav} />}
           </Flex>
         </NavigationMenu.List>
       </NavigationMenu.Root>


### PR DESCRIPTION
Fixes #1113

## What changed?
- Evenly spaced the navigation items in navigation menu for mobile screen sizes.
- Fix navigation issue with the newsletter section when tapped. Actually, the navigation was already working but since the navigation menu was taking the entire screen space in mobile screen sizes, navigating to the newsletter section wasn't visible and the navigation menu had to be explicitly closed.

## How will this change be visible?
- For mobile screen sizes, the navigation items will now have even vertical space between them. 
- Clicking on **Newsletter** nav item link will close the navigation menu and navigate to the newsletter section.

Below is a snapshot for reference:

<img width="961" height="519" alt="image" src="https://github.com/user-attachments/assets/3b465c19-cd40-4d6c-ba4f-a2ffc62ff8bc" />

## How can you test this change?
[x] Manual tests (describe)
Open up browser dev tools, switch to a mobile screen size. Open up the navigation menu, verify the items have even vertical spacing and clicking on the **Newsletter** nav link successfully navigates to the newsletter section.