### PR TITLE
content/1140/thousands separator

### DIFF
--- a/src/components/donate/CampaignCard.tsx
+++ b/src/components/donate/CampaignCard.tsx
@@ -12,6 +12,7 @@ import {
 import { FC, forwardRef } from "react";
 import Image from "next/image";
 import FundProgress from "@/components/donate/FundProgress";
+import currencyFormatter from "@/utils/currencyFormatter";
 
 type Props = {
   imgSrc: string | undefined;
@@ -71,7 +72,7 @@ const CampaignCard: FC<Props> = forwardRef<HTMLDivElement, Props>(
                 {title}
               </Heading>
               <Box asChild mb="4">
-                <Text size="3">Goal: €{goal}</Text>
+                <Text size="3">Goal: {currencyFormatter(goal)}</Text>
               </Box>
             </Box>
             <Flex gap="2" wrap={"wrap"} mx="1" mb="3" mt="auto">


### PR DESCRIPTION
Fixes #1140

## What changed?

Closes #1140

Uses the shared currencyFormatter helper for donate cards.

## How will this change be visible?

Thousands separators are now printed.

<img width="2406" height="934" alt="image" src="https://github.com/user-attachments/assets/d6b3a1c6-9c17-4ba4-b52e-8763dc910c65" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)