### PR TITLE
Fix/1114/footer improve socials spacing tap targets

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -196,11 +196,10 @@ const Footer = () => {
                     href={social.link}
                     key={social.name}
                     target="_blank"
-                    className="sm:hover:!bg-navy-800 sm:hover:!text-white p-1.5"
+                    className="sm:hover:!bg-navy-700 sm:hover:!text-white text-navy-800 p-1.5"
                     aria-label={social.ariaLabel}
                     style={{
                       ...buttonStyle,
-                      color: "var(#082b76)",
                       borderRadius: "100%",
                     }}
                   >

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -196,15 +196,15 @@ const Footer = () => {
                     href={social.link}
                     key={social.name}
                     target="_blank"
-                    className="hover:!bg-navy-500 hover:!text-white"
+                    className="sm:hover:!bg-navy-800 sm:hover:!text-white p-1.5"
                     aria-label={social.ariaLabel}
                     style={{
                       ...buttonStyle,
+                      color: "var(#082b76)",
                       borderRadius: "100%",
-                      padding: "var(--space-1)",
                     }}
                   >
-                    <social.icon size={20} />
+                    <social.icon size={30} />
                   </a>
                 ))}
               </Flex>

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -23,7 +23,7 @@ const ColumnHeading = ({ children }: { children: React.ReactNode }) => (
 );
 
 const FooterLinks = () => (
-  <Flex align="center" gap="2" mt="4">
+  <Flex align="center" gap="2" mt="4" p={"1"}>
     <Text as="p" weight="medium">
       <Link
         href="https://distributeaid.org/whistleblowing-policy"
@@ -138,7 +138,7 @@ const Footer = () => {
               direction={{ initial: "row" }}
             >
               {FOOTER_COLUMNS.map((column, index) => (
-                <Flex key={`column-${index + 1}`} direction="column" gap="3">
+                <Flex key={`column-${index + 1}`} direction="column" gap="4">
                   {column.title && (
                     <ColumnHeading>{column.title}</ColumnHeading>
                   )}
@@ -154,7 +154,7 @@ const Footer = () => {
                           href={link.link}
                           target="_blank"
                           rel="noreferrer"
-                          className="hover:underline"
+                          className="hover:underline p-1 "
                         >
                           {link.name}
                         </a>
@@ -165,7 +165,7 @@ const Footer = () => {
                       <Link
                         key={link.name}
                         href={link.link}
-                        className="hover:underline"
+                        className="hover:underline p-1 "
                       >
                         {link.name}
                       </Link>
@@ -175,7 +175,7 @@ const Footer = () => {
               ))}
             </Flex>
 
-            <Flex direction="column" gap="3" width={{ sm: "30%" }}>
+            <Flex direction="column" gap="4" width={{ sm: "30%" }}>
               <ColumnHeading>Contact us</ColumnHeading>
 
               <Text>


### PR DESCRIPTION
## What changed?
1. 1st commit - 1114 - increased spacing between footer elements and added padding. 
2. 2nd commit - 1107 - updated social icons to increase contrast, remove hover on mobile and increase tap target
Fixes #1114
<!-- include a link to a GitHub issue, if applicable -->
#1114 #1107 
## How will this change be visible?
visible on footer component
<!-- pages, components, etc. -->
`src/components/ui/Footer.tsx`
## How can you test this change?

- [ ] Automated tests
- [x] Manual tests (describe)