### PR TITLE
fix/1121/donate page spacing

### DIFF
--- a/src/components/donate/CopySection.tsx
+++ b/src/components/donate/CopySection.tsx
@@ -2,20 +2,15 @@ import { Box, Text } from "@radix-ui/themes";
 
 const CopySection = () => (
   <Box
-    pt={{
-      initial: "90px",
-      sm: "80px",
-      md: "64px",
-    }}
-    pb="64px"
+    py="20px"
     px={{
       initial: "20px",
       sm: "0",
     }}
-    maxWidth={{ sm: "80%", md: "70%" }}
+    maxWidth="64ch"
     mx="auto"
   >
-    <Text as="p" align={"center"} size={{ initial: "5", md: "6" }}>
+    <Text as="p" align="center" size={{ initial: "5", md: "6" }}>
       Distribute Aid ensures every dollar and diaper donated is put to good use.
       Our logistics management system reduces wasted items and shipping costs,
       including carbon emissions, by significant margins. We don’t pay our


### PR DESCRIPTION
Fixes #1121

## What changed?

Reduce vertical padding around initial paragraph on `/donate`. Closes #1121.

Also updates width to use `ch` units instead of percent so that line lengths stay legible regardless of screen size.

Before:
<img width="1802" height="1960" alt="CleanShot 2026-05-28 at 13 02 08@2x" src="https://github.com/user-attachments/assets/902bb238-721b-48e9-9419-fd2388675dbc" />

After:
<img width="1802" height="1960" alt="CleanShot 2026-05-28 at 13 02 12@2x" src="https://github.com/user-attachments/assets/51234bfb-6d90-4011-ac20-cd8606329022" />

## How will this change be visible?

On `/donate`.

## How can you test this change?

Visual tests