### PR TITLE
Fix/1119/button and spacing

### DIFF
--- a/src/app/tech/page.tsx
+++ b/src/app/tech/page.tsx
@@ -17,6 +17,7 @@ const page = () => {
       direction="column"
       align="center"
       justify="start"
+      px="2"
     >
       <Box
         width="100%"

--- a/src/components/tech/HeroSection.tsx
+++ b/src/components/tech/HeroSection.tsx
@@ -92,8 +92,8 @@ const HeroSection = () => {
               <Link href="mailto:tech@distributeaid.org">
                 <Button size="4">Join Our Team</Button>
               </Link>
-              <Link href="mailto:tech@distributeaid.org">
-                <Button size="4">Become A Sponsor</Button>
+              <Link >
+                <Button className="bg-white text-dark-blue" size="4">Become A Sponsor</Button>
               </Link>
             </Flex>
           </Flex>

--- a/src/components/tech/HeroSection.tsx
+++ b/src/components/tech/HeroSection.tsx
@@ -92,8 +92,10 @@ const HeroSection = () => {
               <Link href="mailto:tech@distributeaid.org">
                 <Button size="4">Join Our Team</Button>
               </Link>
-              <Link >
-                <Button className="bg-white text-dark-blue" size="4">Become A Sponsor</Button>
+              <Link>
+                <Button className="bg-white text-dark-blue" size="4">
+                  Become A Sponsor
+                </Button>
               </Link>
             </Flex>
           </Flex>


### PR DESCRIPTION
Fixes #1119

## What changed?
Closes #1119 by changing the color of one of the buttons and adding padding around the entire page.

## How will this change be visible?
On the tech page:
<img width="1166" height="576" alt="Screenshot from 2026-06-10 12-33-41" src="https://github.com/user-attachments/assets/f8481ece-4452-4564-96c0-76d45fb5e370" />
<img width="444" height="832" alt="Screenshot from 2026-06-10 12-33-15" src="https://github.com/user-attachments/assets/e17bb66e-4e97-48e9-bf7b-eed3f485795a" />

## How can you test this change?
- [ ] Automated tests
- [X] Manual tests (describe)