### PR TITLE
fix/1117/homepage sizing issues

### DIFF
--- a/src/components/home/Impact.tsx
+++ b/src/components/home/Impact.tsx
@@ -7,13 +7,19 @@ import Section from "../ui/SectionWithTitle";
 const OurImpact = () => {
   return (
     <Section title="Our Impact" subTitle="July 2020—June 2025 in numbers">
-      <Grid asChild columns={{ initial: "1", md: "2", lg: "3" }} gap="4">
+      <Grid
+        asChild
+        columns={{ initial: "1", md: "2", lg: "3" }}
+        gap="4"
+        mx={{ initial: "auto" }}
+        maxWidth={{ initial: "1420px" }}
+      >
         <ul>
           {ImpactData.map((item, index) => (
             <li
               key={index}
-              className={`${item.id === 1 && "md:col-span-2 lg:col-span-1"} 
-                    ${item.id === 7 && "xl:col-span-2"} 
+              className={`${item.id === 1 && "md:col-span-2 lg:col-span-1"}
+                    ${item.id === 7 && "xl:col-span-2"}
                     ${item.id === 8 && "md:col-span-2 lg:col-span-1"}`}
             >
               <ImpactCard

--- a/src/components/home/Testimonials.tsx
+++ b/src/components/home/Testimonials.tsx
@@ -47,9 +47,15 @@ const Testimonials = () => {
                         <Text className="text-lg">{role}</Text>
                       </Flex>
                     </Flex>
-                    <blockquote className="font-bold italic text-2xl">
+                    <Text
+                      size={"5"}
+                      style={{
+                        fontStyle: "italic",
+                      }}
+                      weight={"bold"}
+                    >
                       "{quote}"
-                    </blockquote>
+                    </Text>
                   </article>
                 </Flex>
               </li>

--- a/src/components/ui/GetInvolved.tsx
+++ b/src/components/ui/GetInvolved.tsx
@@ -51,7 +51,6 @@ const GetInvolved = () => {
           initial: "1",
           md: "3",
         }}
-        gap="9"
         asChild
         mt="8"
         mb="9"
@@ -60,9 +59,9 @@ const GetInvolved = () => {
           {getInvolvedLinks.map(
             ({ label, buttonLabel, href, bgColor, Icon }) => (
               <li key={label}>
-                <Flex key={label} direction="column" align="center" gap="6">
+                <Flex key={label} direction="column" align="center" gap="5">
                   <Flex
-                    className="h-[228px] w-[228px] rounded-full"
+                    className="size-48 rounded-full"
                     style={{
                       backgroundColor: bgColor,
                     }}
@@ -71,10 +70,10 @@ const GetInvolved = () => {
                   >
                     <Icon />
                   </Flex>
-                  <Text weight="medium" size="8">
+                  <Text weight="medium" size="7">
                     {label}
                   </Text>
-                  <Button size="3" asChild>
+                  <Button size="4" asChild>
                     <a href={href}>{buttonLabel ?? label}</a>
                   </Button>
                 </Flex>

--- a/src/components/ui/GetInvolved.tsx
+++ b/src/components/ui/GetInvolved.tsx
@@ -84,7 +84,13 @@ const GetInvolved = () => {
         </ul>
       </Grid>
 
-      <Box className="bg-fuchsia-100" id="newsletter-signup">
+      <Box
+        style={{
+          backgroundColor: "var(--pink-5)",
+        }}
+        className="text-navy-900"
+        id="newsletter-signup"
+      >
         <Box py="8" px="4" maxWidth="1242px" mx="auto">
           <Heading as="h3" size="8">
             Stay Connected With Distribute Aid
@@ -95,7 +101,7 @@ const GetInvolved = () => {
             aid efforts. No spam—just meaningful insights, once a month.
           </Text>
           {newsletterSuccess ? (
-            <Box className="text-center" m="5">
+            <Box className="text-center " m="5">
               <Heading size="7">Success!</Heading>
               <Text size="4">
                 Thanks for signing up! Please check your email to confirm your

--- a/src/components/ui/SectionWithTitle.tsx
+++ b/src/components/ui/SectionWithTitle.tsx
@@ -50,7 +50,7 @@ export const SectionHeading = ({ id, children }: SectionHeadingProps) => (
     weight="bold"
     align="center"
     mb="4"
-    className="font-yantramanav font-bold text-[60px] leading-[60px] tracking-[-0.16px] text-navy-700"
+    className="font-yantramanav font-bold text-[60px] leading-[60px] tracking-[-0.16px] text-navy-900"
     id={id}
   >
     {children}


### PR DESCRIPTION
Fixes #1117

## What changed?

Closes #1117

Homepage: Adjusted colors and text sizing to better match Figma designs, and adjusted button sizing where possible.

## How will this change be visible?

Home page should look closer to Figma designs.

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)