### PR TITLE
feat/1143/in-kind donor form

### DIFF
--- a/src/components/donate/DonateLandingText.tsx
+++ b/src/components/donate/DonateLandingText.tsx
@@ -27,7 +27,16 @@ const DonateLandingText = () => {
           connecting you with a local hub that can collect your donations.
         </Text>
         <Text align={"center"} weight={"bold"}>
-          If that’s you, reach out to{" "}
+          If that’s you, complete our{" "}
+          <Link
+            href="https://docs.google.com/forms/d/e/1FAIpQLSc_k4arUk6UMZLdK930IMgspyT7m-QoWkRRBj_EWlK_CUKhww/viewform"
+            target="_blank"
+            underline="always"
+            color="blue"
+          >
+            In-Kind Donors Form
+          </Link>{" "}
+          reach out to{" "}
           <Link
             href="mailto:donate-aid@distributeaid.org"
             underline="always"


### PR DESCRIPTION
Fixes #1143

## What changed?

Closes #1143 

Added a link to /donate linking to the in-kind donors form on Google Forms.

## How will this change be visible?

<img width="2234" height="642" alt="image" src="https://github.com/user-attachments/assets/74707a47-a9e8-43dc-8e40-df5a1b7d8dc1" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (Ensure link goes to correct destination and opens in a new tab)