### PR TITLE
feat/1167/response-overview

### DIFF
--- a/src/app/responses/page.tsx
+++ b/src/app/responses/page.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import { Container, Grid, Heading, Section, Text } from "@radix-ui/themes";
+
+import { responses } from "@/data/responses";
+import { ResponseCard } from "@/components/responses/ResponseCard";
+
+const ResponsesOverviewPage: FC = () => (
+  <main>
+    <Section className="bg-navy-900" size="1">
+      <Container>
+        <Heading
+          as="h1"
+          size="9"
+          weight="bold"
+          align="center"
+          className="text-white"
+        >
+          Responses
+        </Heading>
+      </Container>
+    </Section>
+    <Section size="2">
+      <Container>
+        <Text as="p" size="5" align="center" className="text-navy-800" mb="6">
+          Explore Distribute Aid&apos;s active humanitarian responses around the
+          world.
+        </Text>
+        <Grid columns={{ initial: "1", sm: "2", lg: "3" }} gap="5" width="100%">
+          {responses.map((response) => (
+            <ResponseCard key={response.url} response={response} />
+          ))}
+        </Grid>
+      </Container>
+    </Section>
+  </main>
+);
+
+export default ResponsesOverviewPage;

--- a/src/components/responses/ResponseCard.test.tsx
+++ b/src/components/responses/ResponseCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import { ResponseCard } from "./ResponseCard";
+
+afterEach(() => {
+  cleanup();
+});
+
+const mockResponse = {
+  name: "Test Response",
+  url: "/responses/test-response",
+  headerImage: "/test-image.jpg",
+  headerImageAlt: "Test header image",
+  about:
+    "This is a test response description. It contains enough text to verify that the card truncates the about text after one hundred and eighty characters so that the preview stays concise on the overview page.",
+};
+
+describe("ResponseCard", () => {
+  it("renders the response name", () => {
+    render(<ResponseCard response={mockResponse} />);
+
+    expect(
+      screen.getByRole("heading", { name: mockResponse.name }),
+    ).toBeVisible();
+  });
+
+  it("renders a preview of the about text", () => {
+    render(<ResponseCard response={mockResponse} />);
+
+    expect(screen.getByText(/This is a test response/)).toBeVisible();
+  });
+
+  it("links to the response detail page", () => {
+    render(<ResponseCard response={mockResponse} />);
+
+    const link = screen.getByRole("link", { name: "See Details" });
+    expect(link).toHaveAttribute("href", mockResponse.url);
+  });
+});

--- a/src/components/responses/ResponseCard.tsx
+++ b/src/components/responses/ResponseCard.tsx
@@ -1,0 +1,51 @@
+import { FC } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Button, Card, Flex, Heading, Text } from "@radix-ui/themes";
+
+import { ResponseOverview } from "@/data/responses";
+
+const ABOUT_PREVIEW_LENGTH = 180;
+
+const truncateAbout = (text: string) => {
+  if (text.length <= ABOUT_PREVIEW_LENGTH) {
+    return text;
+  }
+
+  return `${text.slice(0, ABOUT_PREVIEW_LENGTH)}…`;
+};
+
+export type ResponseCardProps = {
+  response: ResponseOverview;
+};
+
+export const ResponseCard: FC<ResponseCardProps> = ({
+  response: { name, url, headerImage, headerImageAlt, about },
+}) => (
+  <Card className="h-full overflow-hidden">
+    <Flex direction="column" height="100%">
+      <div className="relative aspect-[16/10] w-full overflow-hidden rounded">
+        <Image
+          src={headerImage}
+          alt={headerImageAlt}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+      </div>
+      <Flex direction="column" gap="3" p="4" flexGrow="1">
+        <Heading as="h2" size="5" className="text-navy-800">
+          {name}
+        </Heading>
+        <Text as="p" size="3" className="text-gray-700">
+          {truncateAbout(about)}
+        </Text>
+        <Flex flexGrow="1" align="end">
+          <Button asChild className="bg-navy-700 text-white hover:bg-navy-800">
+            <Link href={url}>See Details</Link>
+          </Button>
+        </Flex>
+      </Flex>
+    </Flex>
+  </Card>
+);

--- a/src/data/navBarLinks.ts
+++ b/src/data/navBarLinks.ts
@@ -33,33 +33,33 @@ export const links: NavBarLink[] = [
       },
     ],
   },
-  // {
-  //   title: Messages.RESPONSES_PAGE_TITLE,
-  //   url: "/responses",
-  //   isSubMenu: true,
-  //   subMenu: [
-  //     {
-  //       title: Messages.OVERVIEW_NAV_ITEM_TITLE,
-  //       url: "/responses",
-  //     },
-  //     {
-  //       title: Messages.US_DISASTER_PREPAREDNESS_RESPONSE_PAGE_TITLE,
-  //       url: "/responses/us-disaster-preparedness",
-  //     },
-  //     {
-  //       title: Messages.LEVANT_RESPONSE_PAGE_TITLE,
-  //       url: "/responses/levant",
-  //     },
-  //     {
-  //       title: Messages.REFUGEE_SUPPORT_EUROPE_RESPONSE_PAGE_TITLE,
-  //       url: "/responses/refugee-support-eu",
-  //     },
-  //     {
-  //       title: Messages.HRT_TOOLKIT_RESPONSE_PAGE_TITLE,
-  //       url: "/responses/hrt-toolkit",
-  //     },
-  //   ],
-  // },
+  {
+    title: Messages.RESPONSES_PAGE_TITLE,
+    url: "/responses",
+    isSubMenu: true,
+    subMenu: [
+      {
+        title: Messages.OVERVIEW_NAV_ITEM_TITLE,
+        url: "/responses",
+      },
+      {
+        title: Messages.US_DISASTER_PREPAREDNESS_RESPONSE_PAGE_TITLE,
+        url: "/responses/us-disaster-preparedness",
+      },
+      {
+        title: Messages.LEVANT_RESPONSE_PAGE_TITLE,
+        url: "/responses/levant",
+      },
+      {
+        title: Messages.REFUGEE_SUPPORT_EUROPE_RESPONSE_PAGE_TITLE,
+        url: "/responses/refugee-support-eu",
+      },
+      {
+        title: Messages.HRT_TOOLKIT_RESPONSE_PAGE_TITLE,
+        url: "/responses/hrt-toolkit",
+      },
+    ],
+  },
   // {
   //   id: 3,
   //   title: "Needs",

--- a/src/data/responses.ts
+++ b/src/data/responses.ts
@@ -1,0 +1,50 @@
+import { StaticImageData } from "next/image";
+
+import hrtToolkitHeaderImage from "../../public/images/photos/photo-250000-000001-usa-hrt-toolkit.jpg";
+
+export type ResponseOverview = {
+  name: string;
+  url: string;
+  headerImage: StaticImageData | string;
+  headerImageAlt: string;
+  about: string;
+};
+
+export const responses: ResponseOverview[] = [
+  {
+    name: "US Disaster Preparedness",
+    url: "/responses/us-disaster-preparedness",
+    headerImage:
+      "https://res.cloudinary.com/dthervbn8/image/upload/v1756722462/Responses/USA/25-016-USA-USA/IMG_8747_fqfkej.jpg",
+    headerImageAlt:
+      "Emergency supplies being organized for US disaster preparedness",
+    about:
+      "We develop close relationships with mutual aid groups in areas around the country, and create disaster response plans together. Then we secure large quantities of emergency supplies, and pre-position them in centralized hubs. When a disaster strikes, we provide our grassroots partners with the supplies they need to protect their communities.",
+  },
+  {
+    name: "Levant Response",
+    url: "/responses/levant",
+    headerImage:
+      "https://res.cloudinary.com/dthervbn8/image/upload/f_auto/Responses/Levant/Anera%20Photo%20Library/Gaza/gaza_emergency-response_2024-february-20_IMG-20240220-WA0019-EDIT_vstfeb.jpg",
+    headerImageAlt: "Emergency relief being distributed in the Levant",
+    about:
+      "We provide emergency relief to war refugees, and equip them with the tools and training needed to help their own communities. We do this by sourcing bulk quantities of food, medical equipment, and hygiene products from donors—and asking displaced people what they need to heal. Then we package those goods into shipping containers and transport them to Lebanon, Jordan, and occupied Palestine.",
+  },
+  {
+    name: "Refugee Support Europe",
+    url: "/responses/refugee-support-eu",
+    headerImage:
+      "https://res.cloudinary.com/dthervbn8/image/upload/v1741004789/Responses/Refugees%20Europe/Calais/grand_synthe_eviction_jan_21_wjafzm.jpg",
+    headerImageAlt: "Refugee support work in Europe",
+    about:
+      "We deliver supplies to refugee camps, community centers, and grassroots groups serving people on the move. We also work with a network of organizations across the continent to help them be more sustainable and effective by reducing costs and acquiring new sources of aid.",
+  },
+  {
+    name: "HRT Harm Reduction Toolkit",
+    url: "/responses/hrt-toolkit",
+    headerImage: hrtToolkitHeaderImage,
+    headerImageAlt: "HRT Harm Reduction Toolkit supplies",
+    about:
+      "Each kit includes a 1-year supply of medical equipment necessary to administer injection-based hormone therapy. Each kit is worth approximately $65 when purchased at retail value. Using our existing mutual aid networks, the kits are delivered to local frontline organizations who distribute the kits for free to trans people in need.",
+  },
+];


### PR DESCRIPTION
Fixes #1167

## What changed?

Closes #1167 

Adds "response" to navigation bar, and adds response overview page.

## How will this change be visible?

<img width="2598" height="1568" alt="image" src="https://github.com/user-attachments/assets/12ab595f-45ea-4b87-816c-34f4ddf86f3c" />

## How can you test this change?

- [ ] Automated tests
- [ ] Manual tests (describe)